### PR TITLE
채팅 메시지 html 바인딩 안돼는 문제 해결

### DIFF
--- a/puppit/src/main/java/org/puppit/controller/ChatController.java
+++ b/puppit/src/main/java/org/puppit/controller/ChatController.java
@@ -8,6 +8,7 @@ import org.puppit.model.dto.ChatListDTO;
 import org.puppit.model.dto.ChatMessageDTO;
 import org.puppit.model.dto.ChatMessageSelectDTO;
 import org.puppit.service.ChatService;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,25 +26,26 @@ public class ChatController {
 	
 	@GetMapping("/list")
 	public String chats(Model model) {
-		List<ChatListDTO> chatList = chatService.getChatRooms("1");
+		List<ChatListDTO> chatList = chatService.getChatRooms(1);
 		System.out.println("chatList: " + chatList);
 		model.addAttribute("chatList", chatList);		
 		return "chat/list";
 	}
 	
-	@GetMapping("/message")
+	@GetMapping(value = "/message", produces = MediaType.APPLICATION_JSON_VALUE)
 	@ResponseBody
-	public Map<String, Object> chatMessage(ChatMessageSelectDTO chatMessageSelectDTO, Model model) {
+	public List<ChatMessageDTO> chatMessage(ChatMessageSelectDTO chatMessageSelectDTO, Model model) {
 		// 현재로그인된 사용자 (loginUserId가 1번으로 가정), roomId: 1번으로 가정, 
 		System.out.println("/chat/message 요청");
-		List<Map<String, Object>> chatMessages = chatService.getChatMessageList(chatMessageSelectDTO);
-		System.out.println(chatMessageSelectDTO.getLoginUserId() + "가 "  + chatMessageSelectDTO.getRoomId() + "방에서 나눈 대화 : " + chatMessages);
-		model.addAttribute("chatMessages", chatMessages);
+		System.out.println("chatMessageSelectDTO: " + chatMessageSelectDTO.toString());
+		List<ChatMessageDTO> chatMessages = chatService.getChatMessageList(chatMessageSelectDTO);
+		System.out.println("chatMessages.length: " + chatMessages.size());
+		model.addAttribute("chatMessages", chatMessages.toString());
 		model.addAttribute("loginUserId", chatMessageSelectDTO.getLoginUserId());
-		List<ChatListDTO> chatList = chatService.getChatRooms(chatMessageSelectDTO.getRoomId().toString());
+		List<ChatListDTO> chatList = chatService.getChatRooms(chatMessageSelectDTO.getRoomId());
 		model.addAttribute("chatList", chatList);
-		Map<String, Object> map = new HashMap<>();
-	    map.put("chatMessages", chatMessages);
-		return map;
+		//Map<String, Object> map = new HashMap<>();
+	    //map.put("chatMessages", chatMessages);
+		return chatMessages;
 	}
 }

--- a/puppit/src/main/java/org/puppit/model/dto/ChatMessageDTO.java
+++ b/puppit/src/main/java/org/puppit/model/dto/ChatMessageDTO.java
@@ -14,17 +14,29 @@ import lombok.ToString;
 @Setter
 @ToString
 public class ChatMessageDTO {
-	private int messageId;
-	private int chatRoomId;
-	private int productId;
-	private int chatSender;
+	private String messageId;
+	private String chatRoomId;
+	private String productId;
+	private String chatSender;
 	private String chatSenderAccountId;
 	private String chatSenderUserName;
-	private int chatReceiver;
+	private String chatReceiver;
 	private String chatReceiverAccountId;
 	private String chatReceiverUserName;
 	private String chatMessage;
 	private Timestamp chatCreatedAt;
 	private String senderRole;
 	private String receiverRole;
+	@Override
+	public String toString() {
+		return "ChatMessageDTO [messageId=" + messageId + ", chatRoomId=" + chatRoomId + ", productId=" + productId
+				+ ", chatSender=" + chatSender + ", chatSenderAccountId=" + chatSenderAccountId
+				+ ", chatSenderUserName=" + chatSenderUserName + ", chatReceiver=" + chatReceiver
+				+ ", chatReceiverAccountId=" + chatReceiverAccountId + ", chatReceiverUserName=" + chatReceiverUserName
+				+ ", chatMessage=" + chatMessage + ", chatCreatedAt=" + chatCreatedAt + ", senderRole=" + senderRole
+				+ ", receiverRole=" + receiverRole + "]";
+	}
+	
+	
+	
 }

--- a/puppit/src/main/java/org/puppit/model/dto/ChatMessageSelectDTO.java
+++ b/puppit/src/main/java/org/puppit/model/dto/ChatMessageSelectDTO.java
@@ -10,6 +10,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class ChatMessageSelectDTO {
-	private String roomId;
+	private int roomId;
 	private int loginUserId;
 }

--- a/puppit/src/main/java/org/puppit/repository/ChatDAO.java
+++ b/puppit/src/main/java/org/puppit/repository/ChatDAO.java
@@ -19,7 +19,7 @@ public class ChatDAO {
 	
 	private final SqlSessionTemplate sqlSession;
 	
-	public List<ChatListDTO> getChatList(String accountId) {
+	public List<ChatListDTO> getChatList(int accountId) {
 		return sqlSession.selectList("mybatis.mapper.chatMapper.getChatList", accountId);
 	}
 	

--- a/puppit/src/main/java/org/puppit/service/ChatService.java
+++ b/puppit/src/main/java/org/puppit/service/ChatService.java
@@ -8,6 +8,6 @@ import org.puppit.model.dto.ChatMessageDTO;
 import org.puppit.model.dto.ChatMessageSelectDTO;
 
 public interface ChatService {
-	public List<ChatListDTO> getChatRooms(String userId);
-	public List<Map<String, Object>> getChatMessageList(ChatMessageSelectDTO chatMessageSelectDTO);
+	public List<ChatListDTO> getChatRooms(int userId);
+	public List<ChatMessageDTO> getChatMessageList(ChatMessageSelectDTO chatMessageSelectDTO);
 }

--- a/puppit/src/main/java/org/puppit/service/ChatServiceImpl.java
+++ b/puppit/src/main/java/org/puppit/service/ChatServiceImpl.java
@@ -1,7 +1,10 @@
 package org.puppit.service;
 
+
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.puppit.model.dto.ChatListDTO;
 import org.puppit.model.dto.ChatMessageDTO;
@@ -20,14 +23,45 @@ public class ChatServiceImpl implements ChatService{
 	private final ChatDAO chatDAO;
 	
 	@Override
-	public List<ChatListDTO> getChatRooms(String accountId) {
+	public List<ChatListDTO> getChatRooms(int accountId) {
 		
 		return chatDAO.getChatList(accountId);
 	}
 
 	@Override
-	public List<Map<String, Object>> getChatMessageList(ChatMessageSelectDTO chatMessageSelectDTO) {
-		return chatDAO.getChatMessageList(chatMessageSelectDTO);
+	public List<ChatMessageDTO> getChatMessageList(ChatMessageSelectDTO chatMessageSelectDTO) {
+		List<Map<String, Object>> messageList = chatDAO.getChatMessageList(chatMessageSelectDTO);
+		List<ChatMessageDTO> dtoList = messageList.stream().map(message -> {
+			ChatMessageDTO dto = new ChatMessageDTO();
+			dto.setMessageId(String.valueOf(message.get("message_id")));
+			dto.setChatRoomId(String.valueOf(message.get("chat_room_id")) );
+			dto.setProductId(String.valueOf(message.get("product_id")));
+		    dto.setChatSender(String.valueOf(message.get("chat_sender")));
+		    dto.setChatSenderAccountId(String.valueOf(message.get("sender_account_id")));
+	        dto.setChatSenderUserName(String.valueOf(message.get("sender_user_name")));
+	        dto.setChatReceiver(String.valueOf(message.get("chat_receiver")));
+	        dto.setChatReceiverAccountId(String.valueOf(message.get("receiver_account_id")));
+	        dto.setChatReceiverUserName(String.valueOf(message.get("receiver_user_name")));
+	        dto.setChatMessage(String.valueOf(message.get("chat_message")));
+	        // chat_created_at은 Timestamp로 캐스팅 필요
+	        Object createdAt = message.get("chat_created_at");
+	        if (createdAt instanceof Timestamp) {
+	            dto.setChatCreatedAt((Timestamp) createdAt);
+	        } else if (createdAt != null) {
+	            // 만약 DB에서 Long 타입(밀리초)로 오면 변환
+	            try {
+	                dto.setChatCreatedAt(new Timestamp(Long.parseLong(String.valueOf(createdAt))));
+	            } catch (Exception e) {
+	                // 파싱 실패 시 null
+	                dto.setChatCreatedAt(null);
+	            }
+	        }
+	        dto.setSenderRole(String.valueOf(message.get("senderRole")));
+	        dto.setReceiverRole(String.valueOf(message.get("receiverRole")));
+			return dto;
+		}).collect(Collectors.toList());
+		
+		return dtoList;
 	}
 
 }


### PR DESCRIPTION
채팅 메시지 html 바인딩 안돼는 문제 해결

1. DAO에서 반환해주는 List<Map<String, Object>>를  steam을 사용해서 List<CHatMessageDTO>에 담음
이유: jsp에서 데이터 바인딩시 map의 프로퍼티를 카멜케이스로 맞추기 위함
2. JSP의 EL 파싱을 문자열 방식으로 변경
이유: JSP 파일에서 <script> 내부의 ${}는 브라우저가 아니라 JSP 서버가 먼저 보고 해석하려고 해서,
자바스크립트 변수명이 아니라 빈 문자열로 치환되기 때문에,
브라우저에서는 이미 변수가 사라져서 데이터 바인딩이 안 되는 것!
문자열 조립
+
 방식은 이런 해석을 피할 수 있어서 정상 동작한다.