### PR TITLE
meeyoung - 채팅 메시지 css 수정및 BUYER, SELLER 구분 하는 백엔드 수정

### DIFF
--- a/puppit/src/main/java/org/puppit/model/dto/ChatMessageDTO.java
+++ b/puppit/src/main/java/org/puppit/model/dto/ChatMessageDTO.java
@@ -12,7 +12,6 @@ import lombok.ToString;
 @AllArgsConstructor
 @Getter
 @Setter
-@ToString
 public class ChatMessageDTO {
 	private String messageId;
 	private String chatRoomId;

--- a/puppit/src/main/java/org/puppit/service/ChatServiceImpl.java
+++ b/puppit/src/main/java/org/puppit/service/ChatServiceImpl.java
@@ -56,8 +56,8 @@ public class ChatServiceImpl implements ChatService{
 	                dto.setChatCreatedAt(null);
 	            }
 	        }
-	        dto.setSenderRole(String.valueOf(message.get("senderRole")));
-	        dto.setReceiverRole(String.valueOf(message.get("receiverRole")));
+	        dto.setSenderRole(String.valueOf(message.get("sender_role")));
+	        dto.setReceiverRole(String.valueOf(message.get("receiver_role")));
 			return dto;
 		}).collect(Collectors.toList());
 		

--- a/puppit/src/main/resources/mybatis/mapper/chatMessageMapper.xml
+++ b/puppit/src/main/resources/mybatis/mapper/chatMessageMapper.xml
@@ -5,37 +5,50 @@
 <mapper namespace="mybatis.mapper.chatMessageMapper">
   
 <!-- 내가 채팅한 사람과 채팅 메시지를 전부 불러오는 코드, 채팅을 보내는 사람과 받는 사람의 seller, buyer 구분, 어떤 product에 대해서 채팅하고 있는지 -->
+ <!-- 내가 채팅한 사람과 채팅 메시지를 전부 불러오는 코드
+       - 판매자/구매자 역할 구분
+       - 어떤 product에 대한 채팅인지
+       - 역할이 '판매자'일 때 해당 사용자의 seller_id도 함께 반환 -->
 <select id="getChatMessageList" resultType="map" parameterType="org.puppit.model.dto.ChatMessageSelectDTO">
+
 SELECT
-    c.message_id,
-    c.chat_room_id,
-    r.product_id,
-    c.chat_sender,
-    sender.account_id AS sender_account_id,
-    sender.user_name AS sender_user_name,
-    c.chat_receiver,
-    receiver.account_id AS receiver_account_id,
-    receiver.user_name AS receiver_user_name,
-    c.chat_message,
-    c.chat_created_at,
-    CASE
-        WHEN c.chat_sender = #{loginUserId} THEN 'ME'
-        WHEN c.chat_sender = p.seller_id THEN 'SELLER'
-        WHEN c.chat_sender = r.user_id THEN 'BUYER'
-        ELSE 'OTHER'
-    END AS senderRole,
-    CASE
-        WHEN c.chat_receiver = p.seller_id THEN 'SELLER'
-        WHEN c.chat_receiver = r.user_id THEN 'BUYER'
-        ELSE 'OTHER'
-    END AS receiverRole
-FROM chat c
-JOIN room r ON c.chat_room_id = r.room_id
-JOIN product p ON r.product_id = p.product_id
-JOIN user sender ON c.chat_sender = sender.user_id
-JOIN user receiver ON c.chat_receiver = receiver.user_id
-WHERE c.chat_room_id = #{roomId}
-ORDER BY c.chat_created_at ASC
+        c.message_id,
+        c.chat_room_id,
+        r.product_id,
+
+        c.chat_sender,
+        sender.account_id   AS sender_account_id,
+        sender.user_name    AS sender_user_name,
+
+        c.chat_receiver,
+        receiver.account_id AS receiver_account_id,
+        receiver.user_name  AS receiver_user_name,
+
+        c.chat_message,
+        c.chat_created_at,
+
+        -- 내가 보낸/받은 메시지 여부
+        CASE WHEN c.chat_sender   = #{loginUserId} THEN 1 ELSE 0 END AS sender_is_me,
+        CASE WHEN c.chat_receiver = #{loginUserId} THEN 1 ELSE 0 END AS receiver_is_me,
+
+        -- 역할(판매자/구매자) 판정: product.seller_id 기준
+        CASE WHEN c.chat_sender   = p.seller_id THEN 'SELLER' ELSE 'BUYER' END AS sender_role,
+        CASE WHEN c.chat_receiver = p.seller_id THEN 'SELLER' ELSE 'BUYER' END AS receiver_role,
+
+        -- 상품의 seller_id (항상 제공)
+        p.seller_id AS product_seller_id,
+
+        -- 역할이 '판매자'일 때만 해당 컬럼에 seller_id 채움(아니면 NULL)
+        CASE WHEN c.chat_sender   = p.seller_id THEN p.seller_id ELSE NULL END AS sender_seller_id,
+        CASE WHEN c.chat_receiver = p.seller_id THEN p.seller_id ELSE NULL END AS receiver_seller_id
+
+    FROM chat c
+    JOIN room    r ON c.chat_room_id = r.room_id
+    JOIN product p ON r.product_id   = p.product_id
+    JOIN user sender   ON c.chat_sender   = sender.user_id
+    JOIN user receiver ON c.chat_receiver = receiver.user_id
+    WHERE c.chat_room_id = #{roomId}
+    ORDER BY c.chat_created_at ASC;
 </select>
   
 </mapper>

--- a/puppit/src/main/webapp/WEB-INF/views/chat/list.jsp
+++ b/puppit/src/main/webapp/WEB-INF/views/chat/list.jsp
@@ -28,7 +28,6 @@ body {
     font-weight: bold;
     letter-spacing: -1px;
     color: #222;
-    /* display: flex; align-items: center; gap: 6px; 삭제 */
 }
 
 .container {
@@ -81,6 +80,11 @@ body {
     margin-right: 10px;
     border: 1.5px solid #eee;
     background: #fafafa;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 28px;
+    color: #bbb;
 }
 .chat-info-area {
     flex: 1 1 0;
@@ -141,7 +145,7 @@ body {
     height: 600px;
     display: flex;
     flex-direction: column;
-    justify-content: flex-end; /* 입력창을 바닥에 붙임 */
+    justify-content: flex-end;
     padding: 20px;
     box-sizing: border-box;
     background: #fafafa;
@@ -152,11 +156,9 @@ body {
     flex-direction: row;
     gap: 8px;
     width: 100%;
-   
 }
 
 .chat-container input {
-   
     min-width: 0;
     padding: 0 10px;
     font-size: 16px;
@@ -180,68 +182,64 @@ body {
     margin-top: 10px;
 }
 
-.chat-profile-img {
-    width: 56px;
-    height: 56px;
-    border-radius: 50%;
-    object-fit: cover;
-    margin-right: 10px;
-    border: 1.5px solid #eee;
-    background: #fafafa;
-    display: flex;                /* 추가 */
-    justify-content: center;      /* 추가 */
-    align-items: center;          /* 추가 */
-    font-size: 28px;              /* 아이콘 크기 */
-    color: #bbb;                  /* 아이콘 컬러 */
-}
-
-
-/*채팅 메시지들 정렬용 css*/
+/* 채팅 내역(오른쪽 채팅창) */
 .chat-history {
     display: flex;
     flex-direction: column;
+    align-items: flex-start;
+    width: 100%;
     gap: 12px;
     margin-bottom: 16px;
     overflow-y: auto;
     flex: 1;
 }
-.chat-message {
+
+/* 채팅 메시지 버블(여러 줄 지원, BUYER/SELLER 정렬) */
+.chat-history .chat-message {
     max-width: 60%;
+    min-width: 80px;
     padding: 10px 16px;
     border-radius: 12px;
     margin-bottom: 4px;
     display: flex;
     flex-direction: column;
-    word-break: break-all;
+    background: #eee;
+    box-sizing: border-box;
+    word-break: break-word;
+    height: auto;
+    overflow: visible;
 }
-.chat-message.right {
-    align-self: flex-end;
+
+.chat-history .chat-message.right {
+    align-self: flex-end !important;
     background: #e9f7fe;
     text-align: right;
 }
-.chat-message.left {
-    align-self: flex-start;
+.chat-history .chat-message.left {
+    align-self: flex-start !important;
     background: #eee;
     text-align: left;
 }
-.chat-userid {
+
+.chat-history .chat-message .chat-userid {
     font-size: 13px;
     color: #888;
     margin-bottom: 2px;
 }
 
-.chat-text {
+.chat-history .chat-message .chat-text {
     font-size: 15px;
     margin-bottom: 2px;
-    /* 아래 두 줄 추가 */
-    white-space: pre-line;
-    word-break: break-all;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    word-break: break-word;
 }
 
-.chat-time {
+.chat-history .chat-message .chat-time {
     font-size: 12px;
     color: #aaa;
     margin-top: 2px;
+    align-self: flex-end;
 }
 
 
@@ -327,21 +325,22 @@ document.addEventListener('DOMContentLoaded', function() {
                     // 실 데이터 확인
                     console.log('accountId:', msg.chatSenderAccountId, 'username:', msg.chatSenderUserName, 'msg:', msg.chatMessage);
 					                    
-                    // 본인 메시지 구분 (타입 맞추기)
-                    const alignClass = (String(msg.chatSender) === senderId) ? "right" : "left";
-
-                    // 시간 포맷팅 (숫자 → Date)
+                 	// BUYER/SELLER에 따라 정렬 클래스 부여
+                    const alignClass = (msg.senderRole === "BUYER") ? "right" : "left";
+                    console.log('senderRole: ' , msg.senderRole, ' alignClass: ', alignClass); // 이거 추가!
+                 	
                     let chatTime = "";
-				    if (msg.chatCreatedAt) {
-				        chatTime = new Date(msg.chatCreatedAt).toLocaleString('ko-KR');
-				    }
-
-				    html +=
-				        '<div class="chat-message ' + alignClass + '">' +
-				          '<div class="chat-userid">' + msg.chatSenderAccountId + ' (' + msg.chatSenderUserName + ')</div>' +
-				          '<div class="chat-text">' + msg.chatMessage + '</div>' +
-				          '<div class="chat-time">' + chatTime + '</div>' +
-				        '</div>';
+                    if (msg.chatCreatedAt) {
+                        chatTime = new Date(msg.chatCreatedAt).toLocaleString('ko-KR');
+                    }
+                    html +=
+                        '<div class="chat-message ' + alignClass + '">' +
+                            '<div class="chat-userid">' +
+                                msg.chatSenderAccountId + ' (' + msg.chatSenderUserName + ') (' + msg.senderRole + ')' +
+                            '</div>' +
+                            '<div class="chat-text">' + msg.chatMessage + '</div>' +
+                            '<div class="chat-time">' + chatTime + '</div>' +
+                        '</div>';
                 });
                 console.log("최종 html:", html);
 


### PR DESCRIPTION
채팅 메시지 정렬의 핵심:
채팅 버블이 오른쪽 또는 왼쪽(SELLER/BUYER)에 정렬되려면

부모 컨테이너(.chat-history)는 display: flex; flex-direction: column; 구조여야 하며,
각 채팅 메시지(.chat-message)에 align-self: flex-end(오른쪽), align-self: flex-start(왼쪽) 스타일이 정확히 적용되어야 함.
높이 및 오버플로우로 인한 시간(날짜) 잘림

CSS에서 .chat-message에 height를 명시하거나, overflow: hidden을 명시하면
내부에 내용이 길어질 때(메시지+시간 포함) 말풍선이 충분히 늘어나지 못하고
시간 정보가 잘려서 보이지 않게 된다.
부적절한 스타일 상속/우선순위

.chat-message.right, .chat-message.left에서 정렬만 담당해야 하는데
혹시 다른 속성(특히 height/overflow)이 여기서 오버라이드되면 버블이 정상 동작하지 않는다.

어떻게 수정했는가?
1. 높이와 오버플로우 속성 조정
.chat-history .chat-message에
height: auto; overflow: visible;
를 명시하여, 내부 내용(메시지+시간)의 길이만큼 버블이 자연스럽게 늘어나도록 했다.
이로써 시간(날짜) 정보가 말풍선 바깥으로 잘리지 않고, 항상 아래에 표시된다.
2. 정렬 역할만 남김
.chat-message.right에는
align-self: flex-end !important; background: #e9f7fe; text-align: right;
.chat-message.left에는
align-self: flex-start !important; background: #eee; text-align: left;
불필요한 height/overflow 속성은 빼고, 정렬과 배경만 담당하도록 했다.
3. 부모 컨테이너 보강
.chat-history에
display: flex; flex-direction: column; align-items: flex-start; width: 100%;
를 명시해, 자식 요소의 align-self가 제대로 동작하도록 했다.
