### PR TITLE
meeyoung - 채팅창 스크롤바 제거 및 채팅 방 클릭시 가장 최근에 보낸 메시지로 스크롤이 이동될 수 있도록 수정

### DIFF
--- a/puppit/src/main/webapp/WEB-INF/views/chat/list.jsp
+++ b/puppit/src/main/webapp/WEB-INF/views/chat/list.jsp
@@ -192,7 +192,16 @@ body {
     margin-bottom: 16px;
     overflow-y: auto;
     flex: 1;
+    
+     /* 스크롤바 숨기기 (크로스 브라우저) */
+    scrollbar-width: none;         /* Firefox */
+    -ms-overflow-style: none;      /* IE, Edge */
 }
+
+.chat-history::-webkit-scrollbar {
+    display: none;                 /* Chrome, Safari, Opera */
+}
+
 
 /* 채팅 메시지 버블(여러 줄 지원, BUYER/SELLER 정렬) */
 .chat-history .chat-message {
@@ -351,6 +360,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
                 chatHistoryElem.innerHTML = html;
 
+                // [여기 추가]
+                chatHistoryElem.scrollTop = chatHistoryElem.scrollHeight;
+                
                 console.log("chat-history innerHTML:", chatHistoryElem.innerHTML);
             })
             .catch(err => console.error("fetch 실패:", err));


### PR DESCRIPTION
채팅창 스크롤바 제거
.chat-history {
    display: flex;
    flex-direction: column;
    align-items: flex-start;
    width: 100%;
    gap: 12px;
    margin-bottom: 16px;
    overflow-y: auto;
    flex: 1;

    /* 스크롤바 숨기기 (크로스 브라우저) */
    scrollbar-width: none;         /* Firefox */
    -ms-overflow-style: none;      /* IE, Edge */
}
.chat-history::-webkit-scrollbar {
    display: none;                 /* Chrome, Safari, Opera */
}

채팅 방 클릭시 가장 최근에 보낸 메시지가 보이도록 코드 수정
fetch로 채팅 내역을 불러와서 innerHTML로 넣은 직후에
chatHistoryElem.scrollTop = chatHistoryElem.scrollHeight;
를 추가하면 항상 가장 마지막 메시지로 스크롤 이동한다
채팅방 클릭시 항상 마지막 대화내용이 보이게 하기 위함