### PR TITLE
meeyoung - 로그인된 사용자가 채팅한 채팅방 목록 불러오기 기능 수정

### DIFF
--- a/puppit/src/main/java/org/puppit/controller/ChatController.java
+++ b/puppit/src/main/java/org/puppit/controller/ChatController.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.servlet.http.HttpSession;
+
 import org.puppit.model.dto.ChatListDTO;
 import org.puppit.model.dto.ChatMessageDTO;
 import org.puppit.model.dto.ChatMessageProductDTO;
@@ -26,8 +28,9 @@ public class ChatController {
 	private final ChatService chatService;
 	
 	@GetMapping("/list")
-	public String chats(Model model) {
-		List<ChatListDTO> chatList = chatService.getChatRooms(1);
+	public String chats(Model model, HttpSession session) {
+		int userId = (Integer) session.getAttribute("userId");
+		List<ChatListDTO> chatList = chatService.getChatRooms(userId);
 		System.out.println("chatList: " + chatList);
 		model.addAttribute("chatList", chatList);		
 		return "chat/list";

--- a/puppit/src/main/java/org/puppit/model/dto/ChatListDTO.java
+++ b/puppit/src/main/java/org/puppit/model/dto/ChatListDTO.java
@@ -12,26 +12,36 @@ import lombok.ToString;
 @AllArgsConstructor
 @Getter
 @Setter
-@ToString
 public class ChatListDTO {
 	private Integer roomId;
-	private boolean chatIsRead;
-	private String chatMessage;
-	private Timestamp chatSentAt;
-	private String chatSenderId;
-	private String chatReceiverId;
-	private String profileImage;
-	private String senderAccountId;
-	private String receiverAccountId;
-	private int unreadCount;
+	private Integer productId;
+	private String productName;
+	private Integer productPrice;
+	private Integer otherUserId;
+	private String otherAccountId;
+	private String otherUserName;
+	private String lastMessage;
+	private Timestamp lastMessageAT;
+	private Integer lastMessageSenderId;
+	private String lastMessageSenderAccountId;
+	private String lastMessageSenderName;
+	private Integer lastMessageReceiverId;
+	private String lastMessageReceiverAccountId;
+	private String lastMessageReceiverName;
 	
 	@Override
 	public String toString() {
-		return "ChatListDTO [roomId=" + roomId + ", chatIsRead=" + chatIsRead + ", chatMessage=" + chatMessage
-				+ ", chatSentAt=" + chatSentAt + ", chatSenderId=" + chatSenderId + ", chatReceiverId=" + chatReceiverId
-				+ ", profileImage=" + profileImage + ", senderAccountId=" + senderAccountId + ", receiverAccountId="
-				+ receiverAccountId + ", unreadCount=" + unreadCount + "]";
+		return "ChatListDTO [roomId=" + roomId + ", productId=" + productId + ", productName=" + productName
+				+ ", productPrice=" + productPrice + ", otherUserId=" + otherUserId + ", otherAccountId="
+				+ otherAccountId + ", otherUserName=" + otherUserName + ", lastMessage=" + lastMessage
+				+ ", lastMessageAT=" + lastMessageAT + ", lastMessageSenderId=" + lastMessageSenderId
+				+ ", lastMessageSenderAccountId=" + lastMessageSenderAccountId + ", lastMessageSenderName="
+				+ lastMessageSenderName + ", lastMessageReceiverId=" + lastMessageReceiverId
+				+ ", lastMessageReceiverAccountId=" + lastMessageReceiverAccountId + ", lastMessageReceiverName="
+				+ lastMessageReceiverName + "]";
 	}
+	
+	
 	
 	
 	

--- a/puppit/src/main/java/org/puppit/repository/ChatDAO.java
+++ b/puppit/src/main/java/org/puppit/repository/ChatDAO.java
@@ -20,8 +20,8 @@ public class ChatDAO {
 	
 	private final SqlSessionTemplate sqlSession;
 	
-	public List<ChatListDTO> getChatList(int accountId) {
-		return sqlSession.selectList("mybatis.mapper.chatMapper.getChatList", accountId);
+	public List<ChatListDTO> getChatList(int userId) {
+		return sqlSession.selectList("mybatis.mapper.chatMapper.getChatList", userId);
 	}
 	
 	public List<Map<String, Object>> getChatMessageList(ChatMessageSelectDTO chatMessageSelectDTO) {

--- a/puppit/src/main/java/org/puppit/service/ChatServiceImpl.java
+++ b/puppit/src/main/java/org/puppit/service/ChatServiceImpl.java
@@ -24,9 +24,9 @@ public class ChatServiceImpl implements ChatService{
 	private final ChatDAO chatDAO;
 	
 	@Override
-	public List<ChatListDTO> getChatRooms(int accountId) {
+	public List<ChatListDTO> getChatRooms(int userId) {
 		
-		return chatDAO.getChatList(accountId);
+		return chatDAO.getChatList(userId);
 	}
 
 	@Override

--- a/puppit/src/main/resources/mybatis/mapper/chatMapper.xml
+++ b/puppit/src/main/resources/mybatis/mapper/chatMapper.xml
@@ -7,31 +7,44 @@
 <!-- 내가 로그인 해서 내가 채팅한 모든 사용자들과의 마지막 메시지만 불러오는 코드 -->  
 <select id="getChatList" resultType="org.puppit.model.dto.ChatListDTO">
     SELECT
-        c2.chat_room_id AS roomId,
-        c2.is_read AS chatIsRead,
-        c2.chat_message AS chatMessage,
-        c2.chat_created_at AS chatSentAt,
-        c2.chat_sender AS chatSenderId,
-        c2.chat_receiver AS chatReceiverId,
-        sender.account_id AS senderAccountId,
-        receiver.account_id AS receiverAccountId,
-        0 AS unreadCount
-    FROM (
-        SELECT c1.*
-        FROM chat c1
-        INNER JOIN (
-            SELECT chat_room_id, MAX(message_id) AS max_message_id
-            FROM chat
-            WHERE chat_sender = #{userId} OR chat_receiver = #{userId}
-            GROUP BY chat_room_id
-        ) latest
-          ON c1.chat_room_id = latest.chat_room_id
-         AND c1.message_id = latest.max_message_id
-        WHERE c1.chat_sender = #{userId} OR c1.chat_receiver = #{userId}
-    ) AS c2
-    INNER JOIN user AS sender ON sender.user_id = c2.chat_sender
-    INNER JOIN user AS receiver ON receiver.user_id = c2.chat_receiver
-    ORDER BY c2.chat_created_at DESC
+    r.room_id                  AS roomId,
+    p.product_id               AS productId,
+    p.product_name             AS productName,
+    p.product_price            AS productPrice,
+    -- 상대방 정보 (내가 sender면 receiver, 내가 receiver면 sender)
+    CASE
+        WHEN c.chat_sender = #{userId} THEN receiver.user_id
+        ELSE sender.user_id
+    END                        AS otherUserId,
+    CASE
+        WHEN c.chat_sender = #{userId} THEN receiver.account_id
+        ELSE sender.account_id
+    END                        AS otherAccountId,
+    CASE
+        WHEN c.chat_sender = #{userId} THEN receiver.user_name
+        ELSE sender.user_name
+    END                        AS otherUserName,
+    -- 마지막 메시지 정보
+    c.chat_message             AS lastMessage,
+    c.chat_created_at          AS lastMessageAt,
+    c.chat_sender              AS lastMessageSenderId,
+    sender.account_id          AS lastMessageSenderAccountId,
+    sender.user_name           AS lastMessageSenderName,
+    c.chat_receiver            AS lastMessageReceiverId,
+    receiver.account_id        AS lastMessageReceiverAccountId,
+    receiver.user_name         AS lastMessageReceiverName
+FROM (
+    SELECT chat_room_id, MAX(message_id) AS max_message_id
+    FROM chat
+    WHERE chat_sender = #{userId} OR chat_receiver = #{userId}
+    GROUP BY chat_room_id
+) last_msg
+JOIN chat c ON c.chat_room_id = last_msg.chat_room_id AND c.message_id = last_msg.max_message_id
+JOIN room r ON c.chat_room_id = r.room_id
+JOIN product p ON r.product_id = p.product_id
+JOIN user sender ON c.chat_sender = sender.user_id
+JOIN user receiver ON c.chat_receiver = receiver.user_id
+ORDER BY c.chat_created_at DESC
 </select>
   
 </mapper>

--- a/puppit/src/main/webapp/WEB-INF/views/chat/list.jsp
+++ b/puppit/src/main/webapp/WEB-INF/views/chat/list.jsp
@@ -260,23 +260,18 @@ body {
     <div class="chatlist-container">
         <c:forEach items="${chatList}" var="chat">
             <div class="chatList" data-room-id="${chat.roomId}" >
-                <c:choose>
-                    <c:when test="${empty chat.profileImage}">
+                
                         <span class="chat-profile-img chat-profile-icon">
                             <i class="fa-solid fa-user"></i>
                         </span>
-                    </c:when>
-                    <c:otherwise>
-                        <img class="chat-profile-img" src="${chat.profileImage}" alt="profile"/>
-                    </c:otherwise>
-                </c:choose>
+                   
                 <div class="chat-info-area" style="cursor:pointer;">
-                    <div class="chat-nickname">${chat.receiverAccountId}</div>
-                    <div class="chat-message">${chat.chatMessage}</div>
+                    <div class="chat-nickname">${chat.lastMessageReceiverAccountId}</div>
+                    <div class="chat-message">${chat.lastMessage}</div>
                 </div>
                 <div class="chat-meta">
                     <span class="chat-time">
-                        <fmt:formatDate value="${chat.chatSentAt}" pattern="a h시 mm분"/>
+                        <fmt:formatDate value="${chat.lastMessageAT}" pattern="a h시 mm분"/>
                     </span>
                 </div>
             </div>


### PR DESCRIPTION
1. 기존 쿼리의 한계
기존 쿼리(예시):

SQL
```
SELECT
    c2.chat_room_id AS roomId,
    c2.is_read AS chatIsRead,
    c2.chat_message AS chatMessage,
    c2.chat_created_at AS chatSentAt,
    ...
FROM (
    SELECT c1.*
    FROM chat c1
    INNER JOIN (
        SELECT chat_room_id, MAX(message_id) AS max_message_id
        FROM chat
        WHERE chat_sender = #{userId} OR chat_receiver = #{userId}
        GROUP BY chat_room_id
    ) latest
      ON c1.chat_room_id = latest.chat_room_id
     AND c1.message_id = latest.max_message_id
    WHERE c1.chat_sender = #{userId} OR c1.chat_receiver = #{userId}
) AS c2
INNER JOIN user AS sender ON sender.user_id = c2.chat_sender
INNER JOIN user AS receiver ON receiver.user_id = c2.chat_receiver
ORDER BY c2.chat_created_at DESC
```
한계:

상대방 정보(내가 sender면 receiver, 내가 receiver면 sender)의 account_id, user_name 등 추가로 조회 필요
product 정보, 마지막 메시지의 발신자/수신자 정보, 상품 정보, 상대방을 구분하는 로직 부족
2. 수정된 쿼리의 주요 포인트
아래와 같이 쿼리를 보완/수정합니다:

SQL
```
<select id="getChatList" resultType="org.puppit.model.dto.ChatListDTO">
SELECT
    r.room_id                  AS roomId,
    p.product_id               AS productId,
    p.product_name             AS productName,
    p.product_price            AS productPrice,
    -- 상대방 정보
    CASE
        WHEN c.chat_sender = #{userId} THEN receiver.user_id
        ELSE sender.user_id
    END                        AS otherUserId,
    CASE
        WHEN c.chat_sender = #{userId} THEN receiver.account_id
        ELSE sender.account_id
    END                        AS otherAccountId,
    CASE
        WHEN c.chat_sender = #{userId} THEN receiver.user_name
        ELSE sender.user_name
    END                        AS otherUserName,
    -- 마지막 메시지 정보
    c.chat_message             AS lastMessage,
    c.chat_created_at          AS lastMessageAt,
    c.chat_sender              AS lastMessageSenderId,
    sender.account_id          AS lastMessageSenderAccountId,
    sender.user_name           AS lastMessageSenderName,
    c.chat_receiver            AS lastMessageReceiverId,
    receiver.account_id        AS lastMessageReceiverAccountId,
    receiver.user_name         AS lastMessageReceiverName
FROM (
    SELECT chat_room_id, MAX(message_id) AS max_message_id
    FROM chat
    WHERE chat_sender = #{userId} OR chat_receiver = #{userId}
    GROUP BY chat_room_id
) last_msg
JOIN chat c ON c.chat_room_id = last_msg.chat_room_id AND c.message_id = last_msg.max_message_id
JOIN room r ON c.chat_room_id = r.room_id
JOIN product p ON r.product_id = p.product_id
JOIN user sender ON c.chat_sender = sender.user_id
JOIN user receiver ON c.chat_receiver = receiver.user_id
ORDER BY c.chat_created_at DESC
</select>
```
수정/추가된 주요 부분
상대방 정보 구하기

CASE WHEN c.chat_sender = #{userId} THEN receiver.account_id ELSE sender.account_id END AS otherAccountId
내가 보낸 메시지면 receiver, 내가 받은 메시지면 sender가 상대방이다.
마지막 메시지 추출

GROUP BY chat_room_id의 MAX(message_id)로 각 채팅방의 마지막 메시지만 추출한다.
상대방 및 본인 정보 모두 SELECT

sender/receiver의 account_id, user_name, user_id 등 모두 SELECT
필요한 정보는 DTO에 모두 맵핑
상품 정보도 함께 조회

product_id, product_name, product_price 등도 한 번에 조회
정렬

마지막 메시지 전송 시간 기준 내림차순 정렬
3. 왜 이렇게 수정해야 하는가?
실제 채팅방 리스트 UI에서
상대방(닉네임, 아이디, 프로필 등)을 보여주고
방마다 마지막 메시지/시간/보낸 사람이 누구인지도 보여줘야 함
내가 보낸 메시지/상대방이 보낸 메시지 구분이 필요
한 채팅방에 여러 메시지가 있을 때, 마지막 메시지만 뽑기 위해
→ GROUP BY + MAX(message_id)(혹은 MAX(chat_created_at)) 사용