### PR TITLE
meeyoung - 채팅 메시지 조회시 시간표시 수정

### DIFF
--- a/puppit/src/main/webapp/WEB-INF/views/chat/list.jsp
+++ b/puppit/src/main/webapp/WEB-INF/views/chat/list.jsp
@@ -266,7 +266,7 @@ body {
                         </span>
                    
                 <div class="chat-info-area" style="cursor:pointer;">
-                    <div class="chat-nickname">${chat.lastMessageReceiverAccountId}</div>
+                    <div class="chat-nickname">${chat.lastMessageSenderAccountId}</div>
                     <div class="chat-message">${chat.lastMessage}</div>
                 </div>
                 <div class="chat-meta">
@@ -382,10 +382,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 const list = map.chatMessages || [];
                 let html = "";   
                 list.forEach(msg => {
+                	console.log("chatCreatedAt:", msg.chatCreatedAt, typeof msg.chatCreatedAt);
                     const alignClass = (msg.senderRole === "BUYER") ? "right" : "left";
                     let chatTime = "";
                     if (msg.chatCreatedAt) {
                         chatTime = formatKoreanTime(msg.chatCreatedAt);
+                        console.log('chatTime:', chatTime);
                     }
                     html +=
                         '<div class="chat-message ' + alignClass + '">' +
@@ -409,24 +411,47 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 });
 
-// formatKoreanTime은 timestamp(ms)도 지원하게!
-function formatKoreanTime(ts) {
-    if (!ts) return "";
-    let d;
-    if (typeof ts === "string" && ts.length > 0 && !isNaN(Number(ts))) {
-        d = new Date(Number(ts));
-    } else if (typeof ts === "number") {
-        d = new Date(ts);
-    } else {
-        d = new Date(ts);
-    }
-    if (isNaN(d.getTime())) return "";
-    let hour = d.getHours();
-    let min = d.getMinutes();
-    const ampm = hour < 12 ? "오전" : "오후";
-    hour = hour % 12; if (hour === 0) hour = 12;
-    return `${ampm} ${hour}시 ${min < 10 ? '0' + min : min}분`;
-}
+/**
+ * 주어진 값(ts)을 한국식 시간 문자열("오전/오후 h시 mm분")로 변환
+ * 지원 포맷:
+ *  - number (timestamp, 밀리초)
+ *  - ISO8601 문자열 ("2025-08-10T22:29:38.0")
+ *  - "yyyy-MM-dd HH:mm:ss[.S]" (공백 포함 문자열)
+ *  - 숫자 형태의 문자열 ("1754832578000")
+ */
+ function formatKoreanTime(ts) {
+	    if (!ts) return "";
+	    let d;
+
+	    if (typeof ts === "number" || (typeof ts === "string" && !isNaN(Number(ts)))) {
+	        d = new Date(Number(ts));
+	    } else if (typeof ts === "string" && ts.indexOf("T") > 0) {
+	        d = new Date(ts);
+	    } else if (typeof ts === "string" && ts.match(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}/)) {
+	        d = new Date(ts.replace(" ", "T"));
+	    } else {
+	        d = new Date(ts);
+	    }
+
+	    if (!d || isNaN(d.getTime())) return "";
+
+	    let hour = d.getHours();
+	    console.log('hour: ' , hour);
+	    let min = d.getMinutes();
+	    console.log('min: ' , min);
+	    let ampm = hour < 12 ? "오전" : "오후";
+	    console.log('ampm: ', ampm);
+	    let hour12 = hour % 12;
+	    if (hour12 === 0) hour12 = 12;
+	    console.log('hour12:', hour12);
+	    // 여기서 반드시 백틱(`) 사용! 따옴표(') 아님!
+	    // **백틱(`)으로 감싼 것에 주의!**
+   
+    let formatted = `\${ampm} \${hour12}시 \${min < 10 ? '0' + min : min}분`;
+    console.log('formatted:', formatted);
+	    return formatted;
+	}
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
문제 원인 (한 문장 요약)
JSP 페이지가 서버에서 렌더링될 때 **${...}를 JSP EL(Expression Language)**로 먼저 해석해 버려서, 브라우저에 가기 전에 템플릿 리터럴 안의 ${ampm}, ${hour12}, ${min...} 부분이 빈 문자열로 치환되어 버렸습니다. 그래서 클라이언트에서 hour, min, ampm, hour12는 정상적으로 계산되어 로그에 찍히지만, 템플릿 리터럴(백틱) 내부의 ${...}는 이미 서버가 제거해 버렸기 때문에 최종 formatted에는 변수값 대신 빈 자리만 남아 시 분 처럼 보였던 겁니다.

왜 그게 문제인가? (조금 더 기술적으로)
JSP는 서버 사이드 템플릿입니다. JSP 파일을 클라이언트에 보내기 전에 서버가 JSP 문법(JSP EL 포함)을 먼저 처리한다

JavaScript의 템플릿 리터럴 ${...}는 클라이언트(브라우저)가 처리해야 하는 구문인데, JSP가 같은 표기법을 먼저 보고 서버 측 EL로 해석하려고 한다.

서버에 ampm, hour12 같은 EL 변수가 없으면 JSP는 빈 문자열로 바꿔서 클라이언트에 전송한다.

결과: 브라우저로 전달된 소스는 let formatted = \ 시 분`;` 같은 형태가 되어 JS 템플릿이 변수값을 참조할 수 없게 된다.

(처음 의심했던 백틱 깨짐 문제나 new Date() 문제는 이번 경우엔 아니었음 — 로그에서 hour, min, ampm, hour12가 정상 출력되는 것으로 확인.)

어떻게 해결했나 — 선택 가능한 방법들 (구체 코드 포함)
방법 A — 간단하고 권장 : 템플릿 리터럴 대신 문자열 연결 사용 (인라인 JSP에서 안전)
템플릿 리터럴 ${...}를 전혀 쓰지 않으므로 JSP EL과 충돌 없음.

js
복사
편집
function formatKoreanTime(ts) {
  if (!ts) return "";
  const d = new Date(Number(ts)); // 필요하면 *1000 체크
  const hour = d.getHours();
  const min = d.getMinutes();
  const ampm = hour < 12 ? "오전" : "오후";
  const hour12 = hour % 12 || 12;

  // 템플릿 리터럴 대신 문자열 덧셈 사용
  const formatted = ampm + " " + hour12 + "시 " + (min < 10 ? "0" + min : min) + "분";
  console.log("formatted:", formatted);
  return formatted;
}
이 방식은 JSP가 서버에서 뭘 하든 클라이언트 JS에서 정상 동작한다.