### PR TITLE
채팅 메시지 팝업창 상태를 로컬스토리지에서 관리

### DIFF
--- a/puppit/src/main/webapp/WEB-INF/views/layout/header.jsp
+++ b/puppit/src/main/webapp/WEB-INF/views/layout/header.jsp
@@ -224,217 +224,195 @@ a{text-decoration:none;color:inherit;}
 	//채팅방 접속 상태
 	let currentChatRoomId = null;
 	let alarmShownOnce = false;
-	// 1. LocalStorage에서 알림 닫힘 상태 읽기
-	let alarmClosed = localStorage.getItem('puppitAlarmClosed') === 'true';
+	
+	
 	
   var btn = document.getElementById('do-search');
   var results = document.getElementById('search-results');
   var autoList = document.getElementById('autocompleteList');
- 
-//종버튼 클릭 시 알림창 재오픈
-  document.addEventListener("DOMContentLoaded", function() {
-	  var alarmArea = document.getElementById("alarmArea");
-	  var alarmBell = document.getElementById("alarmBell");
-	if (isLoggedIn === "true" && userId && !isNaN(userId)) {
-		  if (!alarmClosed) {
-	            alarmArea.style.display = "block";
-	            if (alarmBell) alarmBell.style.display = "none"; // 팝업 띄우면 종 숨김
-	            loadAlarms();
-	            setInterval(loadAlarms, 30000);
-	            connectNotificationSocket(); // 실시간 알림 연결
-	        } else {
-	            alarmArea.style.display = "none";
-	            alarmArea.innerHTML = "";
-	            if (alarmBell) alarmBell.style.display = "inline-block"; // 닫힌 상태엔 종 항상 보임!
-	        }
-     }  
-	  
-    var alarmBell = document.getElementById("alarmBell");
-    if (alarmBell) {
-    	alarmBell.addEventListener("click", function() {
-    		alarmClosed = false;
-			localStorage.setItem('puppitAlarmClosed', 'false');
-			alarmShownOnce = false;
-			loadAlarms();
-			alarmArea.style.display = "block";
-			alarmBell.style.display = "none";
-			window.alarmInterval = setInterval(loadAlarms, 30000);
-			alarmBell.classList.remove('red'); // 클릭하면 원상복구
-    	    });
-    }
-  });
   
-//웹소켓(Stomp) 연결 및 구독
-  function connectNotificationSocket() {
-    var socket = new SockJS(contextPath + '/ws-stomp'); // 서버의 SockJS endpoint 맞게 수정
-    stompClient = Stomp.over(socket);
-    stompClient.connect({}, function (frame) {
-      stompClient.subscribe('/topic/chat', function (notificationMsg) {
-        let notification = JSON.parse(notificationMsg.body);
-        // 본인에게 온 알림만 표시
-        if (String(notification.receiverAccountId || notification.userId) !== String(userId)) return;
-     	// 채팅방에 접속중이면 알림 띄우지 않음
-        if (String(currentChatRoomId) === String(notification.roomId)) return;
-        onChatMessageReceived(notification);
-     	
-        
-        // 중복 방지: messageId 기준
-        // 기존 알림 리스트에 중복 messageId가 있으면 건너뜀
-        let alarmArea = document.getElementById("alarmArea");
-        let existing = alarmArea.innerHTML || "";
-        if (existing.includes(notification.messageId)) return;
+  // 1. 페이지가 로딩될 때마다 알림 닫힘 상태를 항상 false로 초기화!
 
-        // 알림 영역에 바로 추가 (중복 messageId 확인 생략 가능, 필요하면 추가)
-        showAlarmPopup([notification]);
-      });
+let alarmClosed = false; // 변수 초기화 OK
+
+document.addEventListener("DOMContentLoaded", function() {
+  var alarmArea = document.getElementById("alarmArea");
+  var alarmBell = document.getElementById("alarmBell");
+
+  // 로그인 상태일 때만 알림 로직
+  if (isLoggedIn === "true" && userId && !isNaN(userId)) {
+    // 최초 접속/새로고침: localStorage 값 없으면 팝업 열림
+    if (localStorage.getItem('puppitAlarmClosed') === null) {
+      alarmClosed = false;
+      localStorage.setItem('puppitAlarmClosed', 'false');
+    } else {
+      alarmClosed = localStorage.getItem('puppitAlarmClosed') === 'true';
+    }
+
+    if (!alarmClosed) {
+      alarmArea.style.display = "block";
+      alarmBell.style.display = "none";
+      loadAlarms();
+      setInterval(loadAlarms, 30000);
+      connectSocket();
+    } else {
+      alarmArea.style.display = "none";
+      alarmArea.innerHTML = "";
+      alarmBell.style.display = "inline-block";
+    }
+  }
+  // 종버튼 클릭: 알림창 오픈, 닫힘상태 false
+  if (alarmBell) {
+    alarmBell.addEventListener("click", function() {
+      alarmClosed = false;
+      localStorage.setItem('puppitAlarmClosed', 'false');
+      alarmShownOnce = false;
+      loadAlarms();
+      alarmArea.style.display = "block";
+      alarmBell.style.display = "none";
+      window.alarmInterval = setInterval(loadAlarms, 30000);
+      alarmBell.classList.remove('red');
     });
   }
+});
+  
+//1. 웹소켓 연결 및 구독 (알림+채팅 모두)
+  function connectSocket() {
+    var socket = new SockJS(contextPath + '/ws-chat');
+    stompClient = Stomp.over(socket);
+    stompClient.connect({}, function(frame) {
+        // 알림 메시지 구독 (모든 알림)
+        stompClient.subscribe('/topic/notification', function(msg) {
+          console.log('msg: ', msg);
+          let notification = JSON.parse(msg.body);
+          // 본인에게 온 알림만
+          if (String(notification.receiverAccountId || notification.userId) !== String(userId)) return;
+          // [핵심] 채팅방에 접속중이 아닐 때 알림 팝업!
+          if (String(currentChatRoomId) !== String(notification.roomId)) {
+            showAlarmPopup([notification]);
+            const alarmBell = document.getElementById("alarmBell");
+            if (alarmBell) {
+              alarmBell.classList.add('red');
+              alarmBell.style.display = "inline-block";
+            }
+          }
+        });
+        // 채팅 메시지 구독 (모든 채팅방)
+        stompClient.subscribe('/topic/chat', function(msg) {
+          let chat = JSON.parse(msg.body);
+          // 본인에게 온 메시지라면 무시 (알림만 뜨게 할 경우 상대방이 보낸 것만)
+          if (String(chat.chatSenderAccountId) === String(userId)) return;
+          // [핵심] 채팅방에 접속중이 아닐 때 알림 팝업!
+          if (String(currentChatRoomId) !== String(chat.chatRoomId)) {
+            showAlarmPopup([chat]);
+            const alarmBell = document.getElementById("alarmBell");
+            if (alarmBell) {
+              alarmBell.classList.add('red');
+              alarmBell.style.display = "inline-block";
+            }
+          }
+        });
+      });
+ }
 
-	// 접속자 관리 함수
+//접속자 관리 함수 (채팅방 입장/퇴장시 호출)
 	function setUserInRoom(roomId, role) {
 		if (!activeRooms[roomId]) activeRooms[roomId] = { buyer: false, seller: false };
 		activeRooms[roomId][role.toLowerCase()] = true;
+		currentChatRoomId = roomId;
 	}
 	function setUserOutRoom(roomId, role) {
 		if (!activeRooms[roomId]) return;
 		activeRooms[roomId][role.toLowerCase()] = false;
+		currentChatRoomId = null;
 	}
 	function isUserInRoom(roomId, role) {
 		return activeRooms[roomId] && activeRooms[roomId][role.toLowerCase()];
 	}
-  
-
-
-  // 채팅방 입장 시
-  function enterChatRoom(roomId) {
-    currentChatRoomId = roomId;
-  }
-
-  // 채팅방 퇴장 시
-  function leaveChatRoom() {
-    currentChatRoomId = null;
-  }
-
-  // 알림 메시지 수신 시
-  function handleIncomingAlarm(alarm) {
-	// 내가 현재 그 채팅방에 접속중이면 알림을 띄우지 않는다
-	  if (String(currentChatRoomId) === String(alarm.roomId)) {
-	    return;
-	  }
-	  // 알림 영역에 메시지 추가
-	  showAlarmInPopup(alarm);
-  }
-  
-  
-
-  console.log("userId JS:", userId); // 값이 없다면 fetch 요청 안 감
-
-  function showAlarmPopup(alarms = [], force = false) {
-	  if (alarmClosed && !force) return;
-	  if (alarmShownOnce && !force) return;
-
-	  if (!Array.isArray(alarms)) alarms = [alarms];
-
-	  var alarmArea = document.getElementById("alarmArea");
-	  var html = '<button class="alarm-close" onclick="closeAlarmPopup()" title="닫기">&times;</button><ul>';
-
-	  // 중복 제거: messageId 기준
-	  const msgIdSet = new Set();
-	  const deduped = alarms.filter(alarm => {
-	    if (!alarm || !alarm.roomId || !alarm.messageId) return false;
-	    if (msgIdSet.has(alarm.messageId)) return false;
-	    msgIdSet.add(alarm.messageId);
-	    return true;
-	  });
-
-	  deduped.forEach(function(alarm) {
-	    html += '<li>'
-	      + '<a href="' + contextPath + '/chat/recentRoomList?highlightRoomId=' + alarm.roomId  + '&highlightMessageId=' + (alarm.messageId || '') + '" style="color:inherit;text-decoration:none;">'
-	      + '<b>새 메시지:</b> ' + (alarm.chatMessage || '')
-	      + ' <span style="color:#aaa;">(' + (alarm.productName || '') + ')</span>'
-	      + ' <span style="color:#888;">' + (alarm.messageCreatedAt || '') + '</span><br>'
-	      + '<span style="font-size:13px;">From: ' + (alarm.senderAccountId || '') + ' | To: ' + (alarm.receiverAccountId || '') + '</span>'
-	      + '</li>';
-	  });
-	  html += '</ul>';
-	  alarmArea.innerHTML = html;
-	  alarmArea.style.display = "block";
-	  alarmShownOnce = true;
-  }
-  
-  function closeAlarmPopup() {
+	// 알림 팝업 처리
+   function showAlarmPopup(alarms = [], force = false) {
+    console.log('alarms: ', alarms);
+    if (alarmClosed && !force) return;
+    if (alarmShownOnce && !force) return;
+    if (!Array.isArray(alarms)) alarms = [alarms];
     var alarmArea = document.getElementById("alarmArea");
-    alarmArea.style.display = "none";
-    alarmArea.innerHTML = ""; // 요소 내용 완전히 비움!
-    var alarmBell = document.getElementById("alarmBell");
-    if (alarmBell) alarmBell.style.display = "inline-block";
-    if(window.alarmInterval) clearInterval(window.alarmInterval);
-    alarmClosed = true; // 알림창 닫힘 상태로 변경
-    localStorage.setItem('puppitAlarmClosed', 'true'); // 닫힘상태 저장
-  }
+    var html = '<button class="alarm-close" onclick="closeAlarmPopup()" title="닫기">&times;</button><ul>';
+    const msgIdSet = new Set();
+    const deduped = alarms.filter(alarm => {
+      if (!alarm || !alarm.roomId || !alarm.messageId) return false;
+      if (msgIdSet.has(alarm.messageId)) return false;
+      msgIdSet.add(alarm.messageId);
+      return true;
+    });
+    deduped.forEach(function(alarm) {
+      html += '<li>'
+        + '<a href="' + contextPath + '/chat/recentRoomList?highlightRoomId=' + alarm.roomId  + '&highlightMessageId=' + (alarm.messageId || '') + '" style="color:inherit;text-decoration:none;">'
+        + '<b>새 메시지:</b> ' + (alarm.chatMessage || '')
+        + ' <span style="color:#aaa;">(' + (alarm.productName || '') + ')</span>'
+        + ' <span style="color:#888;">' + (alarm.messageCreatedAt || '') + '</span><br>'
+        + '<span style="font-size:13px;">From: ' + (alarm.senderAccountId || '') + ' | To: ' + (alarm.receiverAccountId || '') + '</span>'
+        + '</li>';
+    });
+    html += '</ul>';
+    alarmArea.innerHTML = html;
+    alarmArea.style.display = "block";
+    alarmShownOnce = true;
+   }
+
+	  function closeAlarmPopup() {
+		    var alarmArea = document.getElementById("alarmArea");
+		    alarmArea.style.display = "none";
+		    alarmArea.innerHTML = "";
+		    var alarmBell = document.getElementById("alarmBell");
+		    if (alarmBell) alarmBell.style.display = "inline-block";
+		    if(window.alarmInterval) clearInterval(window.alarmInterval);
+		    alarmClosed = true;
+		    localStorage.setItem('puppitAlarmClosed', 'true');
+		  }
+
+	  function loadAlarms() {
+		    var alarmArea = document.getElementById("alarmArea");  
+		    if (alarmClosed) {
+		    	console.log('alarm closed');
+		      alarmArea.style.display = "none";
+		      alarmArea.innerHTML = "";
+		      var alarmBell = document.getElementById("alarmBell");
+		      if (alarmBell) alarmBell.style.display = "inline-block";
+		      return;
+		    }
+		    if (!userId || isNaN(userId)) {
+		      alarmArea.innerHTML = "";
+		      alarmArea.style.display = "none";
+		      return;
+		    }
+		    fetch(contextPath + "/api/alarm?userId=" + userId)
+		      .then(res => {
+		        if (!res.ok) throw new Error("서버 오류");
+		        return res.json();
+		      })
+		      .then(data => {
+		    	  console.log('data: ', data);
+		        if (data.length === 0) {
+		          alarmArea.innerHTML = "";
+		          alarmArea.style.display = "none";
+		          var alarmBell = document.getElementById("alarmBell");
+		          if (alarmBell) alarmBell.style.display = "inline-block";
+		        } else {
+		          showAlarmPopup(data);
+		        }
+		      })
+		      .catch(err => {
+		        console.error(err);
+		        alarmArea.innerHTML = '<span style="color:red;">알림을 불러올 수 없습니다.</span>';
+		        alarmArea.style.display = "block";
+		        showAlarmPopup([], true);
+		      });
+		  }
 
   
 
-
-
-  function loadAlarms() {
-	var alarmArea = document.getElementById("alarmArea");  
-	if (alarmClosed) {
-	    alarmArea.style.display = "none";
-	    alarmArea.innerHTML = ""; // 닫힘상태면 html도 완전히 비움!
-	    var alarmBell = document.getElementById("alarmBell");
-		if (alarmBell) alarmBell.style.display = "inline-block";
-		return;
-	}
-	
-    if (!userId || isNaN(userId)) {
-    	alarmArea.innerHTML = "";
-        alarmArea.style.display = "none";
-        return;
-    }
-    
-    console.log("userId: ", userId);
-    fetch(contextPath + "/api/alarm?userId=" + userId)
-      .then(res => {
-        if (!res.ok) throw new Error("서버 오류");
-        return res.json();
-      })
-      .then(data => {
-        //var alarmArea = document.getElementById("alarmArea");   
-        console.log("data: ", data);
-        //var html = '<button class="alarm-close" onclick="closeAlarmPopup()" title="닫기">&times;</button>';
-        if (data.length === 0) {
-           // 알림이 하나도 없으면 알림 팝업/영역을 숨긴다
-        	 alarmArea.innerHTML = "";
-             alarmArea.style.display = "none";
-             var alarmBell = document.getElementById("alarmBell");
-		if (alarmBell) alarmBell.style.display = "inline-block";
-        } else {
-        	showAlarmPopup(data); // 알림 객체 배열을 넘겨줌!
-        }
-      })
-      .catch(err => {
-    	  console.error(err);
-    	  alarmArea.innerHTML = '<span style="color:red;">알림을 불러올 수 없습니다.</span>';
-          alarmArea.style.display = "block";
-          showAlarmPopup([], true);
-      });
-  }
-
-//메시지 수신시 접속자 체크 후 종모양 색/크기 변경
-	function onChatMessageReceived(chat) {
-		console.log('chat: ', chat);
-		const buyerInRoom = isUserInRoom(chat.chatRoomId, "BUYER");
-		const sellerInRoom = isUserInRoom(chat.chatRoomId, "SELLER");
-		const alarmBell = document.getElementById("alarmBell");
-		// 구매자 또는 판매자 중 한 명이라도 접속 중이 아니면 종모양 빨간색/크기 변경
-		if (!buyerInRoom || !sellerInRoom) {
-			if (alarmBell) {
-				alarmBell.classList.add('red');
-				alarmBell.style.display = "inline-block";
-			}
-		}
-	}
+  
+  
   
   async function loadCategory(categoryName) {
 	  results.innerHTML = '<div class="empty">카테고리 불러오는 중...</div>';


### PR DESCRIPTION
localStorage.setItem('puppitAlarmClosed', 'false');
→ 이 코드가 페이지 로드 시 무조건 실행되면 안됩니다!
→ 반드시 localStorage 값이 없을 때만 기본값을 넣어야 합니다.
이렇게 하면
→ 사용자가 팝업을 끄고 페이지를 이동해도
→ localStorage의 값이 유지되어
→ 팝업이 자동으로 다시 뜨지 않습니다.