### PR TITLE
채팅 메시지 알림 목록 로그인 사용자 기준으로 필터 변경

### DIFF
--- a/puppit/src/main/webapp/WEB-INF/views/layout/header.jsp
+++ b/puppit/src/main/webapp/WEB-INF/views/layout/header.jsp
@@ -281,8 +281,9 @@ document.addEventListener("DOMContentLoaded", function() {
   }
 
   if (alarmBell) {
-    alarmBell.addEventListener("click", function() {
+	  alarmBell.addEventListener("click", function() {
       alarmClosed = false;
+      console.log("alarmBell button clicked"); // 버튼 클릭시 찍힘
       localStorage.setItem('puppitAlarmClosed', 'false');
       alarmArea.style.display = "block";
       alarmBell.style.display = "none";
@@ -389,12 +390,14 @@ document.addEventListener("DOMContentLoaded", function() {
 	  // filter 내부에서도 찍힘
 	  const msgIdSet = new Set();
 	  const deduped = alarms.filter((alarm, idx) => {
-	    console.log(`filter alarm[${idx}]:`, alarm);
-	    if (!alarm || !alarm.roomId || !alarm.messageId) return false;
-	    if (msgIdSet.has(alarm.messageId)) return false;
-	    msgIdSet.add(alarm.messageId);
-	    return true;
-	  });
+		  console.log(`filter alarm[${idx}]:`, alarm);
+		  if (!alarm || !alarm.roomId || !alarm.messageId) return false;
+		  if (msgIdSet.has(alarm.messageId)) return false;
+		  // receiverAccountId와 loginUserId가 같을 때만
+		  if (String(alarm.receiverAccountId) !== String(loginUserId)) return false;
+		  msgIdSet.add(alarm.messageId);
+		  return true;
+		});
 
 	  // deduped 결과도 찍기
 	  console.log('deduped:', deduped);
@@ -488,6 +491,11 @@ document.addEventListener("DOMContentLoaded", function() {
 		      })
 		      .then(data => {
 		    	  console.log('data: ', data);
+		    	// === 로그인한 사용자가 receiver로 받은 알림만 보여주기 ===
+			    const filtered = Array.isArray(data)
+  ? data.filter(alarm => String(alarm.receiverAccountId) === String(loginUserId))
+  : [];
+  console.log('filtered: ', filtered);
 		        if (data.length === 0) {
 		          alarmArea.innerHTML = "";
 		          alarmArea.style.display = "none";


### PR DESCRIPTION
 알림 목록에서 로그인 사용자 기준 필터링 로직 개선
기존에는 알림 중복 메시지만 필터링하고 receiver가 로그인 사용자(loginUserId)인지 체크하지 않았다.
요구사항은 로그인된 사용자가 receiverAccountId인 알림만 보여줘야 했으므로,
filter 조건을 추가하여 receiverAccountId와 loginUserId가 일치하는 경우만 남기도록 수정하였다.
기술적 해결
filter 함수 내에 String(alarm.receiverAccountId) === String(loginUserId) 조건을 추가.
중복 메시지 필터링과 receiver 기준 필터링을 동시에 처리하여 알림 목록의 정확성 및 사용자 경험을 개선함.