### PR TITLE
채팅방 클릭시 안읽은 메시지 개수 배지 삭제하여 읽음처리로 변경

### DIFF
--- a/puppit/src/main/java/org/puppit/controller/ChatApiAlarmController.java
+++ b/puppit/src/main/java/org/puppit/controller/ChatApiAlarmController.java
@@ -85,4 +85,12 @@ public class ChatApiAlarmController {
 	        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
 	    }
 	}
+	
+	@GetMapping(value = "/chat/unreadCount", produces = MediaType.APPLICATION_JSON_VALUE)
+	@ResponseBody
+	public Map<Integer, Integer> getUnreadCounts(@RequestParam Integer userId) {
+	    return alarmService.getUnreadCountsForUser(userId);
+	}
+	
+	
 }

--- a/puppit/src/main/java/org/puppit/repository/AlarmDAO.java
+++ b/puppit/src/main/java/org/puppit/repository/AlarmDAO.java
@@ -33,4 +33,22 @@ public class AlarmDAO {
 	     return sqlSessionTemplate.update("mybatis.mapper.alarmMapper.updateAllReadStatus", param);
 	}
 
+	 /**
+     * 각 채팅방별 미읽은 메시지 개수를 반환
+     * @param userId 로그인한 사용자 id
+     * @return Map<roomId, unreadCount>
+     */
+    public Map<Integer, Integer> getUnreadCountsForUser(int userId) {
+        List<Map<String, Object>> resultList = sqlSessionTemplate.selectList(
+            "mybatis.mapper.alarmMapper.getUnreadCountsForUser", userId);
+
+        Map<Integer, Integer> unreadCountMap = new HashMap<>();
+        for (Map<String, Object> row : resultList) {
+            Integer roomId = ((Number) row.get("room_id")).intValue();
+            Integer count = ((Number) row.get("unread_count")).intValue();
+            unreadCountMap.put(roomId, count);
+        }
+        return unreadCountMap;
+    }
+
 }

--- a/puppit/src/main/java/org/puppit/service/ChatAlarmService.java
+++ b/puppit/src/main/java/org/puppit/service/ChatAlarmService.java
@@ -1,10 +1,13 @@
 package org.puppit.service;
 
+import java.util.Map;
+
 import org.puppit.model.dto.AlarmReadDTO;
 
 public interface ChatAlarmService {
 	public Integer readAlarm(Integer messageId);
 	public int markAsRead(AlarmReadDTO dto);
 	public int markAllAsRead(Integer roomId, Integer userId, Integer groupCount);
+	public Map<Integer, Integer> getUnreadCountsForUser(Integer userId);
 	
 }

--- a/puppit/src/main/java/org/puppit/service/ChatAlarmServiceImpl.java
+++ b/puppit/src/main/java/org/puppit/service/ChatAlarmServiceImpl.java
@@ -1,5 +1,7 @@
 package org.puppit.service;
 
+import java.util.Map;
+
 import org.puppit.model.dto.AlarmReadDTO;
 import org.puppit.repository.AlarmDAO;
 import org.springframework.stereotype.Service;
@@ -30,6 +32,12 @@ public class ChatAlarmServiceImpl implements ChatAlarmService {
 	@Override
 	public int markAllAsRead(Integer roomId, Integer userId, Integer groupCount) {
 	 return alarmDAO.updateAllReadStatus(roomId, userId, groupCount);
+	}
+	
+	@Override
+	public Map<Integer, Integer> getUnreadCountsForUser(Integer userId) {
+	    // 쿼리: SELECT room_id, COUNT(*) FROM alarm WHERE user_id = :userId AND is_read = 1 GROUP BY room_id
+	    return alarmDAO.getUnreadCountsForUser(userId);
 	}
 
 }

--- a/puppit/src/main/resources/mybatis/mapper/alarmMapper.xml
+++ b/puppit/src/main/resources/mybatis/mapper/alarmMapper.xml
@@ -25,21 +25,33 @@ WHERE r.room_id = #{roomId}
     </update>
   
   
-<update id="updateAllReadStatus" parameterType="map">
-   UPDATE alarm
-SET is_read = 0
-WHERE message_id IN (
-    SELECT t.message_id
-    FROM (
-        SELECT a.message_id
-        FROM alarm a
-        JOIN chat c ON a.message_id = c.message_id
-        WHERE a.room_id = #{roomId}
-          AND c.chat_receiver = #{userId}
-          AND a.is_read = 1
-        ORDER BY a.message_id DESC
-        LIMIT 7
-    ) t
-);
-</update>
+	<update id="updateAllReadStatus" parameterType="map">
+	   UPDATE alarm
+	SET is_read = 0
+	WHERE message_id IN (
+	    SELECT t.message_id
+	    FROM (
+	        SELECT a.message_id
+	        FROM alarm a
+	        JOIN chat c ON a.message_id = c.message_id
+	        WHERE a.room_id = #{roomId}
+	          AND c.chat_receiver = #{userId}
+	          AND a.is_read = 1
+	        ORDER BY a.message_id DESC
+	        LIMIT 7
+	    ) t
+	);
+	</update>
+
+	<select id="getUnreadCountsForUser" parameterType="int" resultType="map">
+	    SELECT a.room_id, COUNT(*) AS unread_count
+		FROM alarm a
+		JOIN chat c ON a.message_id = c.message_id
+		WHERE a.is_read = 1
+		  AND c.chat_receiver = #{userId}
+		GROUP BY a.room_id;
+	</select>
+
+
+
 </mapper>


### PR DESCRIPTION
# 채팅방 미읽은 메시지 뱃지(알림 뱃지) 클릭 시 UI/서버 동기화 기능 개발 논리 및 해결 과정

## 1. **기능 요구사항 및 목표**

- 사용자가 채팅방 목록에서 "미읽은 메시지 개수" 알림 뱃지가 붙은 채팅방을 클릭하면,
    - 해당 채팅방의 **미읽은 메시지 상태가 서버에서 읽음으로 처리**되고,
    - **UI상 뱃지가 즉시 사라지며 (알림 팝업에서도 사라짐)**
    - 기존 채팅방 입장/메시지 전송 등 기능에는 영향이 없어야 한다.

---

## 2. **기술적 접근 및 구조 설계**

### **A. 프론트엔드의 역할**

- **채팅방 클릭 이벤트**를 감지하여,
- 해당 채팅방에 미읽음 뱃지가 있으면,
    - 서버에 "읽음 처리" API를 호출
    - API 성공 시 UI에서 뱃지 및 알림 팝업의 해당 항목을 즉시 제거

#### **구현 논리**
1. **채팅방 목록의 각 채팅방(`.chatList`)에 클릭 이벤트 리스너 등록**
2. 클릭 시, 채팅방의 미읽음 뱃지(`.unread-badge`)가 보이는지 확인
3. 보인다면, 서버에 `POST /api/chat/readAll`로 roomId, userId, count를 전달
4. 응답 성공 시:
    - 해당 채팅방의 뱃지 DOM 요소를 숨김/초기화
    - 알림 팝업(`alarmArea`)에서도 해당 roomId의 알림 항목을 제거
5. 이후 기존 채팅방 입장 및 메시지 불러오기 등은 정상 동작

### **B. 백엔드의 역할**

- **API 엔드포인트 구현**: `/api/chat/readAll`
    - `roomId`, `userId`, `count`를 받아서,
    - `chat` 테이블과 `alarm` 테이블을 JOIN하여
    - 해당 user가 수신자인(roomId, chat_receiver=userId) 모든 메시지의 `is_read` 값을 0(읽음)으로 변경
- **트랜잭션 보장:** 여러 메시지의 상태를 한번에 일괄 변경

---

## 3. **주요 문제점과 기술적 해결 과정**

### **A. 404 Not Found & JSON 파싱 에러**

- **문제:** 프론트가 `/api/chat/readAll`로 POST 요청을 보내지만 서버에 해당 엔드포인트가 없어 404 에러 발생.  
    - 결과적으로 HTML 에러 페이지가 반환되어 JS에서 `res.json()` 파싱 에러 발생

- **해결:**  
    1. **서버에 해당 엔드포인트 구현**  
        - Spring Controller에 `@PostMapping("/readAll")` 추가
        - 필요한 모델/파라미터 처리 및 DB 쿼리 작성
    2. **프론트에서 응답 상태 체크 추가**  
        - `if(!res.ok) throw new Error('API not found')`로 오류 상황을 명확히 분기 처리
    3. **DB에서 JOIN UPDATE 쿼리 작성**  
        - chat, alarm을 JOIN하여 roomId, userId(chat_receiver) 기준으로 여러 메시지 일괄 업데이트

### **B. UI/서버 동기화 문제**

- **문제:** 뱃지만 로컬에서 사라지고 실제 서버 메시지 상태가 바뀌지 않으면, 새로고침 시 다시 뱃지가 나타남

- **해결:**  
    - **서버 상태가 변경된 후에만 UI에서 뱃지/알림 제거**
    - API 성공 후만 DOM 조작하도록 구현해서 서버와 UI 상태 불일치 문제를 방지

---

## 4. **핵심 논리 요약 및 포트폴리오 활용 포인트**

- **사용자 경험(UX) 강화:**  
    - 클릭 한 번으로 서버의 메시지 상태와 UI 뱃지가 즉각적으로 동기화되어, 실시간 피드백 제공
- **RESTful API와 프론트-백엔드 분리:**  
    - 프론트는 상태 변경 요청만, 백엔드는 실제 데이터 상태 관리와 트랜잭션 처리
- **에러 핸들링 및 복구 로직 설계:**  
    - API 미존재/실패 상황을 명확히 처리하여 서비스 안정성 강화
- **확장성:**  
    - 알림 팝업, 채팅방 목록 등 여러 UI 컴포넌트에서 동일한 서버 상태를 반영할 수 있도록 설계
- **DB/서버 효율성:**  
    - JOIN UPDATE로 다수 메시지를 한번에 변경, 트랜잭션으로 일관성 보장

---

## 5. **결론**

> "사용자가 채팅방 목록에서 미읽음 메시지 뱃지가 있는 방을 클릭하면,  
> 서버와 UI가 실시간으로 동기화되어 알림 뱃지가 사라지는 기능을  
> 프론트엔드/백엔드 협업 및 트랜잭션적 DB 처리, 에러 복구 설계까지 고려해 구현했습니다.  
> 이 과정에서 RESTful API 설계와 프론트-서버 상태 동기화, 에러 핸들링의 중요성을 직접 경험했고,  
> 실서비스에서 빠르고 일관성 있는 사용자 경험을 제공할 수 있는 기술적 역량을 키웠습니다."