### PR TITLE
채팅 메시지 알림 팝업 UI 수정 및 알림 메시지 읽음 처리 수정

### DIFF
--- a/puppit/src/main/java/org/puppit/controller/ChatApiAlarmController.java
+++ b/puppit/src/main/java/org/puppit/controller/ChatApiAlarmController.java
@@ -9,6 +9,7 @@ import javax.servlet.http.HttpSession;
 import org.puppit.model.dto.AlarmReadDTO;
 import org.puppit.model.dto.NotificationDTO;
 import org.puppit.model.dto.UserDTO;
+import org.puppit.repository.UserDAO;
 import org.puppit.service.ChatAlarmService;
 import org.puppit.service.ChatService;
 import org.puppit.service.UserService;
@@ -35,6 +36,7 @@ public class ChatApiAlarmController {
 	private final ChatService chatService;
 	private final ChatAlarmService alarmService;
 	private final UserService userService;
+	private final UserDAO userDAO;
 	
 	
 	@GetMapping(value = "/alarm",  produces = MediaType.APPLICATION_JSON_VALUE)
@@ -49,8 +51,9 @@ public class ChatApiAlarmController {
 	@ResponseBody
 	public ResponseEntity<?> readAlarm(@RequestBody AlarmReadDTO alarmReadDTO) {
 	    try {
+	    	System.out.println("AlarmReadDTO: "+ alarmReadDTO.toString());
 	        System.out.println("messageId: " + alarmReadDTO.getMessageId());
-	        UserDTO user = userService.getUserId(alarmReadDTO.getChatReceiver());
+	        UserDTO user = userDAO.getUserByUserId(alarmReadDTO.getChatReceiver());
 	        if (user == null) {
 	            Map<String, Object> result = new HashMap<>();
 	            result.put("result", "fail");

--- a/puppit/src/main/java/org/puppit/controller/ChatWebSocketController.java
+++ b/puppit/src/main/java/org/puppit/controller/ChatWebSocketController.java
@@ -171,6 +171,8 @@ public class ChatWebSocketController {
         notification.setProductName(chatService.getProductNameById(productId));
         notification.setMessageId(Integer.parseInt(chatMessageDTO.getMessageId())); // 메시지 고유 ID 사용
         notification.setIsRead(1);
+        notification.setChatSender(chatMessageDTO.getChatSender());
+        notification.setChatReceiver(chatMessageDTO.getChatReceiver());
 
         Integer alarmInsertRowId = chatService.saveAlarmData(notification);
         System.out.println("메시지 알림 저장 성공: " + alarmInsertRowId);

--- a/puppit/src/main/java/org/puppit/model/dto/AlarmReadDTO.java
+++ b/puppit/src/main/java/org/puppit/model/dto/AlarmReadDTO.java
@@ -14,7 +14,7 @@ import lombok.ToString;
 public class AlarmReadDTO {
 	private Integer roomId;
 	private Integer userId;
-	private String chatReceiver;
+	private Integer chatReceiver;
 	private Integer chatReceiverUserId;
 	private Integer messageId;
 }

--- a/puppit/src/main/webapp/WEB-INF/views/layout/header.jsp
+++ b/puppit/src/main/webapp/WEB-INF/views/layout/header.jsp
@@ -287,7 +287,7 @@ border-bottom:1px solid #f3f3f3;
         <div>${sessionScope.sessionMap.nickName}님 환영합니다!</div>
         <a href="${contextPath}/user/mypage">마이페이지</a>
 
-        <button id="alarmBell" style="background:none;border:none;display:none;cursor:pointer;font-size:22px;margin-left:8px;" title="알림창 열기">
+        <button id="alarmBell" style="background:none;border:none;display:inline-block;cursor:pointer;font-size:22px;margin-left:8px;" title="알림창 열기">
           <i class="fa-regular fa-bell"></i>
        </button>
 
@@ -621,12 +621,18 @@ document.addEventListener("DOMContentLoaded", function() {
 
 		    // 1. /chat/recentRoomList가 아닌 경우 무조건 알림 팝업
 		       if (window.location.pathname.indexOf("/chat/recentRoomList") === -1) {
-		           displayNotification(data.senderAccountId,
+		           displayNotification(
+		        		   data.roomId,
+		        		   data.chatReceiver,
+		        		   data.chatSender,
+		        		   data.senderAccountId,
 		                   data.chatMessage,
 		                   data.senderRole,
 		                   data.chatCreatedAt,
 		                   data.productName,
-		                   data.receiverAccountId);
+		                   data.receiverAccountId,
+		                   data.messageId);
+		           
 		           
 		       }
 
@@ -635,12 +641,17 @@ document.addEventListener("DOMContentLoaded", function() {
 		           window.location.pathname !== "/chat/recentRoomList" ||
 		           String(currentRoomId) !== String(data.roomId)
 		       ) {
-		           displayNotification( data.senderAccountId,
+		           displayNotification( 
+		        		   data.roomId,
+		        		   data.chatReceiver,
+		        		   data.chatSender,
+		        		   data.senderAccountId,
 		                   data.chatMessage,
 		                   data.senderRole,
 		                   data.chatCreatedAt,
 		                   data.productName,
-		                   data.receiverAccountId);
+		                   data.receiverAccountId,
+		                   data.messageId);
 		       }
 
 		  });
@@ -648,41 +659,45 @@ document.addEventListener("DOMContentLoaded", function() {
 	
 	
 
-	function displayNotification(senderAccountId, chatMessage, senderRole, chatCreatedAt, productName, receiverAccountId) {
+	function displayNotification(roomId, chatReceiver, chatSender, senderAccountId, chatMessage, senderRole, chatCreatedAt, productName, receiverAccountId, messageId) {
+	  console.log('header - roomId: ', roomId);
 	  console.log('header - senderAccountId: ', senderAccountId);
 	  console.log('header - chatMessage: ', chatMessage);
 	  console.log('header - senderRole: ', senderRole);
 	  console.log('header - chatCreatedAt: ', chatCreatedAt);
 	  console.log('header - productName: ', productName);
 	  console.log('header - receiverAccountId: ', receiverAccountId);
+	  console.log('header - chatSender: ', chatSender);
+	  console.log('header - chatReceiver: ', chatReceiver);
+	  console.log('header - messageId: ', messageId);
 
-	  const notification = document.createElement('div');
-	  notification.className = 'notification';
+	 
+	   // 알림 객체 생성 (showAlarmPopup에서 요구하는 구조와 유사하게)
+	  const alarm = {
+	    roomId: roomId, // roomId가 있으면 넣어주세요 (없으면 null로)
+	    messageId: messageId,
+	    chatMessage: chatMessage,
+	    productName: productName,
+	    chatSender: chatSender,
+	    chatReceiver: chatReceiver,
+	    chatCreatedAt: chatCreatedAt,
+	    senderAccountId: senderAccountId,
+	    receiverAccountId: receiverAccountId,
+	    messageCreatedAt: chatCreatedAt || new Date().toISOString(),
+	  };
+	
+	  // 팝업 알림 UI로 표시 (showAlarmPopup 함수 사용)
+	  showAlarmPopup([alarm]);
+	 
+	 
 
-	  notification.innerHTML =
-	      '<button class="alarm-close" onclick="closeAlarmPopup()" title="닫기">&times;</button>' +
-	      '<ul>' +
-	          '<li>' +
-	              '<a href="javascript:void(0);" ' +
-	              'class="alarm-link" ' +
-	              'data-chat-message="' + (chatMessage || '').replace(/"/g, '&quot;') + '">' +
-	              '<b>새 메시지:</b> ' + (chatMessage || '') +
-	              ' <span style="color:#aaa;">(' + (productName || '') + ')</span>' +
-	              ' <span style="color:#888;">' + (chatCreatedAt || '') + '</span>' +
-	              '<br><span style="font-size:13px;">From: ' + (senderAccountId || '') + ' | To: ' + (receiverAccountId || '') + '</span>' +
-	              '</a>' +
-	          '</li>' +
-	      '</ul>';
+	 // setTimeout(() => {
+	  //    notification.style.right = '20px';
+	 // }, 100);
 
-	  document.body.appendChild(notification);
-
-	  setTimeout(() => {
-	      notification.style.right = '20px';
-	  }, 100);
-
-	  setTimeout(() => {
-	      notification.remove();
-	  }, 120000);
+	//  setTimeout(() => {
+	//      notification.remove();
+	//  }, 120000);
 	}
 	
 	
@@ -799,10 +814,15 @@ document.addEventListener("DOMContentLoaded", function() {
 	  // 중복 메시지 제거만 수행 (receiver 체크는 이미 filteredAlarm에서 처리)
 	  const msgIdSet = new Set();
 	  const deduped = alarms.filter((alarm) => {
-	    if (!alarm || !alarm.roomId || !alarm.messageId) return false;
-	    if (msgIdSet.has(alarm.messageId)) return false;
-	    msgIdSet.add(alarm.messageId);
-	    return true;
+	  if (!alarm || !alarm.roomId || !alarm.messageId) return false;
+	  if (msgIdSet.has(alarm.messageId)) return false;
+	  if (typeof alarm.chatReceiverUserId === 'undefined' || alarm.chatReceiverUserId === null) {
+		  if (typeof alarm.chatReceiver !== 'undefined' && alarm.chatReceiver !== null) {
+		      alarm.chatReceiverUserId = alarm.chatReceiver;
+		    }
+	  }
+	  msgIdSet.add(alarm.messageId);
+	   return true;
 	  });
 	  // deduped 결과도 찍기
 	  console.log('deduped:', deduped);
@@ -810,7 +830,7 @@ document.addEventListener("DOMContentLoaded", function() {
 	  // === 팝업 UI용 roomId별로 그룹화 및 집계 ===
 	  // { roomId: { alarms: [], lastAlarm: {}, count: N } }
  	  const roomGroups = {};
-		deduped.forEach(alarm => {
+ 	 deduped.forEach(alarm => {
 		  const roomId = alarm.roomId;
 		  if (!roomGroups[roomId]) {
 		    roomGroups[roomId] = { alarms: [], lastAlarm: null };
@@ -844,16 +864,29 @@ document.addEventListener("DOMContentLoaded", function() {
 	  var html = '<button class="alarm-close" onclick="closeAlarmPopup()" title="닫기">&times;</button><ul>';
 	  Object.values(roomGroups).forEach(group => {
 	    const alarm = group.lastAlarm;
+	    console.log('안읽은 메시지: ', group.count);
+	    // 안전하게 문자열 변환
+	    let safeChatMessage = '';
+	    if (typeof alarm.chatMessage === 'string') {
+	      safeChatMessage = alarm.chatMessage;
+	    } else if (alarm.chatMessage == null) {
+	      safeChatMessage = '';
+	    } else {
+	      safeChatMessage = String(alarm.chatMessage);
+	    }
+	    
+	    
+	    
 	    html += '<li>'
 	      + '<a href="javascript:void(0);" '
 	      + 'class="alarm-link" '
 	      + 'data-room-id="' + alarm.roomId + '" '
 	      + 'data-message-id="' + (alarm.messageId || '') + '" '
-	      + 'data-chat-message="' + (alarm.chatMessage || '').replace(/"/g, '&quot;') + '" '
+	      + 'data-chat-message="' + safeChatMessage.replace(/"/g, '&quot;') + '" '
 	      + '>'
-	      + '<b>새 메시지:</b> ' + (alarm.chatMessage || '')
+	      + '<b>새 메시지:</b> ' + safeChatMessage
 	      + ' <span style="color:#aaa;">(' + (alarm.productName || '') + ')</span>'
-	      + ' <span style="color:#888;">' + (alarm.messageCreatedAt || '') + '</span>';
+	      + ' <span style="color:#888;">' + formatTimestamp(alarm.chatCreatedAt)  + '</span>';
 	      
 	      // 여기서 group.count가 2 이상이면 표시
 	      if (group.count && group.count > 1) {
@@ -873,10 +906,24 @@ document.addEventListener("DOMContentLoaded", function() {
 		      var roomId = alarmLink.getAttribute('data-room-id');
 		      var chatMessage = alarmLink.getAttribute('data-chat-message');
 		      var messageId = alarmLink.getAttribute('data-message-id'); // 메시지의 고유 ID
-
+				console.log('roomId: ', roomId , ' chatMessage: ', chatMessage ,' messageId: ', messageId);
+		      
 		      // deduped[idx]가 현재 alarm 객체!
 		      var alarm = deduped[idx];
 
+		      // 추가: chatReceiver, chatReceiverUserId 가져오기
+		      var chatReceiver = alarm.chatReceiver || alarm.receiverAccountId;
+		      var chatReceiverUserId = alarm.chatReceiverUserId || alarm.userId; // userId가 receiverUserId 역할이라면
+
+		      // 로그 출력
+		          // 로그 출력
+    console.log('로그 roomId:', roomId, 
+                '로그 chatMessage:', chatMessage, 
+                '로그 messageId:', messageId, 
+                '로그 chatReceiver:', chatReceiver, 
+                '로그 chatReceiverUserId:', chatReceiverUserId);
+		      
+		      
 		      // 1. li 제거
 		      var liElem = alarmLink.closest('li');
 		      if (liElem) liElem.remove();
@@ -884,14 +931,25 @@ document.addEventListener("DOMContentLoaded", function() {
 		      // 2. 현재 클릭한 roomId에 해당하는 group.count 찾기
 		      //var groupCount = 1; // 기본값
 	    	  var groupCount = roomGroups && roomGroups[roomId] && roomGroups[roomId].count ? roomGroups[roomId].count : 1;
-
+			  console.log('groupCount: ', groupCount);
+			  
+			  
+			  
+			  
 
 		      // 3. groupCount 값에 따라 분기
 		      if (groupCount === 1) {
+		    	    console.log('groupCount === 1 roomId:', roomId, 
+		                    'groupCount === 1 chatMessage:', chatMessage, 
+		                    'groupCount === 1 messageId:', messageId, 
+		                    'groupCount === 1 chatReceiver:', chatReceiver, 
+		                    'groupCount === 1 chatReceiverUserId:', chatReceiverUserId);
+		    		      
+		    		      
 		        fetch(contextPath + '/api/alarm/read', {
 		          method: 'POST',
 		          headers: { 'Content-Type': 'application/json' },
-		          body: JSON.stringify({ roomId: roomId, userId: userId, messageId: messageId })
+		          body: JSON.stringify({ roomId: roomId, userId: userId, messageId: messageId, chatReceiver: chatReceiver,chatReceiverUserId: chatReceiverUserId   })
 		        })
 		        .then(res => {
 		          if (!res.ok) throw new Error('알림 읽음 처리 실패');
@@ -947,6 +1005,35 @@ document.addEventListener("DOMContentLoaded", function() {
 	  
 	}
 
+	function formatTimestamp(ts) {
+		  if (!ts) return '';
+		  const d = new Date(Number(ts));
+		  if (isNaN(d.getTime())) return '';
+		  // 오전/오후 구분 (a)
+		  const hours = d.getHours();
+		  const ampm = hours < 12 ? '오전' : '오후';
+		  // 0-padding 함수
+		  const pad = n => n < 10 ? '0' + n : n;
+		  return [
+		    d.getFullYear(),
+		    '-',
+		    pad(d.getMonth() + 1),
+		    '-',
+		    pad(d.getDate()),
+		    ' ',
+		    ampm,
+		    ' ',
+		    pad(hours % 12 === 0 ? 12 : hours % 12),
+		    ':',
+		    pad(d.getMinutes()),
+		    ':',
+		    pad(d.getSeconds())
+		  ].join('');
+		}
+	
+	
+	
+	
 	  function closeAlarmPopup() {
 		    //var alarmArea = document.getElementById("alarmArea");
 		    alarmArea.style.display = "none";
@@ -1010,6 +1097,7 @@ document.addEventListener("DOMContentLoaded", function() {
 		  fetch(contextPath + '/api/chat/unreadCount?userId=' + userId)
 		    .then(res => res.json())
 		    .then(unreadCounts => {
+		    	
 		      updateUnreadBadges(unreadCounts);
 		    });
 		}


### PR DESCRIPTION
1. 문제 상황
웹 기반 메신저/알림 팝업 기능을 개발하는 과정에서, 다음과 같은 문제가 발생했습니다:

채팅 메시지 알림 팝업에 표시되는 송신자/수신자 정보(From/To)가 실제 계정명(ID)이 아니라 숫자(userId) 또는 엉뚱한 값으로 출력됨
채팅 메시지의 수신자 필드가 null 또는 undefined로 들어와서 프론트엔드에서 알림 클릭 시 값이 제대로 전달되지 않음
채팅 메시지의 발송 시각(chatCreatedAt)이 UNIX timestamp로만 표기되어, 사용자에게 가독성 있는 날짜/시간(yyyy-MM-dd 오전/오후 hh:mm:ss) 포맷으로 제공되지 않음
알림 팝업이 화면에서 위치가 어색하게 뜨거나, 중복 표기되는 현상 발생
2. 원인 분석
백엔드에서 알림 메시지 객체를 생성할 때, chatReceiver/chatSender 등 계정명 또는 userId를 일관성 있게 주입하지 않음
→ 프론트에서 receiver 정보를 사용할 때 undefined 또는 숫자(userId)만 활용되어 계정명이 표시되지 않음
프론트엔드에서 알림 객체를 가공할 때, receiverAccountId 등 필요한 정보가 누락되거나 덮어써지는 상황 발생
날짜 포맷 변환이 미구현되어, timestamp 그대로 화면에 노출됨
팝업 생성 시 이전 팝업을 지우지 않고, 새 팝업이 추가되어 위치가 어색해짐
3. 해결 과정
(1) 알림 객체의 계정명 정보 일관성 확보
백엔드에서 알림 메시지 DTO를 생성할 때, senderAccountId/receiverAccountId와 userId 모두를 정확히 할당하도록 서버 코드를 개선
userId는 숫자, AccountId는 실제 계정명(문자열)로 명확히 구분
프론트에서 알림 객체를 파싱할 때, receiverAccountId를 항상 표시용 To에 활용
(2) 프론트엔드에서 알림 객체 데이터 가공 로직 보완
알림 객체를 렌더링하기 전, receiverAccountId, senderAccountId 등 계정명 필드가 항상 존재하도록 보강
deduped.forEach에서 누락된 필드가 있으면 기존 값에서 보완
JavaScript
deduped.forEach(alarm => {
  if (!alarm.senderAccountId && alarm.chatSenderAccountId) alarm.senderAccountId = alarm.chatSenderAccountId;
  if (!alarm.receiverAccountId && alarm.chatReceiverAccountId) alarm.receiverAccountId = alarm.chatReceiverAccountId;
});
(3) 날짜 포맷 변환 함수 구현 및 적용
UNIX timestamp를 사람이 읽기 쉬운 형식(yyyy-MM-dd 오전/오후 hh:mm:ss)으로 변환하는 JS 함수를 제작
JavaScript
function formatTimestamp(ts) {
  if (!ts) return '';
  const d = new Date(Number(ts));
  if (isNaN(d.getTime())) return '';
  const hours = d.getHours();
  const ampm = hours < 12 ? '오전' : '오후';
  const pad = n => n < 10 ? '0' + n : n;
  return [
    d.getFullYear(), '-', pad(d.getMonth() + 1), '-', pad(d.getDate()),
    ' ', ampm, ' ', pad(hours % 12 === 0 ? 12 : hours % 12),
    ':', pad(d.getMinutes()), ':', pad(d.getSeconds())
  ].join('');
}
알림 팝업 생성시
js
+ '<span>' + formatTimestamp(alarm.chatCreatedAt) + '</span>'
(4) 알림 팝업 중복/위치 문제 개선
팝업 생성 시 기존 알림 팝업을 반드시 제거하고 새로 렌더링
alarmArea.innerHTML을 새로 갱신
CSS 위치 고정 및 z-index 조정
4. 결과 및 성과
알림 팝업에 송신자/수신자 정보가 실제 계정명으로 정확히 표시됨(예: From: test09 | To: salltest100)
알림 클릭 시 receiver 정보가 정상적으로 서버에 전달되어 읽음 처리 로직이 오류 없이 동작
메시지 발송 시각이 가독성 높은 형태로 제공되어, 사용자 경험(UX)이 크게 향상됨
팝업이 항상 지정된 위치(오른쪽 상단)에 정상적으로 뜨며, 중복 렌더링 없이 깔끔하게 동작