### PR TITLE
채팅방에서 마지막 메시지 전송 날짜 업데이트 돼도록 수정

### DIFF
--- a/puppit/src/main/java/org/puppit/controller/ChatController.java
+++ b/puppit/src/main/java/org/puppit/controller/ChatController.java
@@ -109,10 +109,20 @@ public class ChatController {
 	        @RequestParam(value = "highlightRoomId", required = false) Integer highlightRoomId,
 	        @RequestParam(value = "highlightMessageId", required = false) Integer highlightMessageId,
 	        Model model, HttpSession session) {
-	    Map<String, Object> map = (Map<String, Object>) session.getAttribute("sessionMap");
+	    System.out.println("/recentRoomList");
+		Map<String, Object> map = (Map<String, Object>) session.getAttribute("sessionMap");
 	    int userId = Integer.parseInt(map.get("userId").toString());
 	    Map<String, Object> chatMap = chatService.getChatRoomsByCreatedDesc(userId);
+	   
+	   
+	 // chatMap이 {"roomId": ..., "lastMessage": ..., "lastMessageAt": ...} 와 같은 구조라고 가정
+	    Object lastMessageAtObj = chatMap.get("lastMessageAt");
 
+	    // null 체크 후 String으로 변환
+	    String lastMessageAt = (lastMessageAtObj != null) ? lastMessageAtObj.toString() : null;
+
+	    // 사용 예시
+	    System.out.println("lastMessageAt = " + lastMessageAt);
 	    model.addAttribute("chatList", chatMap.get("chats"));
 	    model.addAttribute("profileImage", chatMap.get("profileImage"));
 	    model.addAttribute("highlightRoomId", highlightRoomId);

--- a/puppit/src/main/java/org/puppit/controller/ChatWebSocketController.java
+++ b/puppit/src/main/java/org/puppit/controller/ChatWebSocketController.java
@@ -1,5 +1,6 @@
 package org.puppit.controller;
 
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
@@ -74,6 +75,27 @@ public class ChatWebSocketController {
 
 	    System.out.println("isFirstChat: " + chatService.isFirstChat(chatRoomId));
 
+	    // createdAt
+	    String createdAtStr = chatMessageDTO.getChatCreatedAt().toString();
+	    Timestamp createdAtTimestamp;
+	    
+	    try {
+	    	// ISO 문자열일 때
+	    	if (createdAtStr.contains("T")) {
+	    		createdAtStr = createdAtStr.replace("T", " ");
+	    	}
+	    	createdAtTimestamp = Timestamp.valueOf(createdAtStr);
+	    	chatMessageDTO.setChatCreatedAt(createdAtTimestamp);
+	    } catch (Exception e) {
+	    	// 값이 업거나 잘못된 경우 현재 시각으로 대체
+	    	chatMessageDTO.setChatCreatedAt(new Timestamp(System.currentTimeMillis()));
+	    }
+	    System.out.println("createdAt: " + chatMessageDTO.getChatCreatedAt());
+	    
+	    
+	    
+	    
+	    
 	    // 메시지 중복 확인
 	    chatMessageDTO.setChatSender(sender.getUserId());
 	    if (chatService.isMessageDuplicate(chatMessageDTO)) {

--- a/puppit/src/main/java/org/puppit/model/dto/ChatListDTO.java
+++ b/puppit/src/main/java/org/puppit/model/dto/ChatListDTO.java
@@ -25,7 +25,6 @@ public class ChatListDTO {
 	private String otherAccountId;
 	private String otherUserName;
 	private String lastMessage;
-	private Timestamp lastMessageAT;
 	private Integer lastMessageSenderId;
 	private String lastMessageSenderAccountId;
 	private String lastMessageSenderName;
@@ -33,8 +32,9 @@ public class ChatListDTO {
 	private String lastMessageReceiverAccountId;
 	private String lastMessageReceiverName;
 	private Timestamp sortTime;
-	private Timestamp chatCreatedAt; // 마지막 메시지 생성 시간 추가
+	private Timestamp lastMessageAt; // 마지막 메시지 생성 시간 추가
 	private String otherProfileImageKey;
+	private String chatLastMessageAt;
 
 	
 }

--- a/puppit/src/main/java/org/puppit/repository/ChatDAO.java
+++ b/puppit/src/main/java/org/puppit/repository/ChatDAO.java
@@ -2,7 +2,8 @@ package org.puppit.repository;
 
 
 import java.math.BigInteger;
-
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -94,9 +95,27 @@ public class ChatDAO {
          List<ChaListProfileImageDTO> chatProfileImages = selectChatRoomListWithProfile(paramMap);
          resultMap.put("profileImage", chatProfileImages);
          List<ChatListDTO> chatList = sqlSession.selectList("mybatis.mapper.chatMessageMapper.getChatRoomsByCreatedDesc", paramMap);
+
+         // Mapper/Service에서 변환
+         for (int i = 0; i < chatList.size(); i++) {
+        	 Timestamp t = chatList.get(i).getLastMessageAt();
+        	 String formatted = formatTimestamp(t); // "2025-08-28 09:34:10" 
+        	 chatList.get(i).setChatLastMessageAt(formatted);
+         }
+         
+               
          resultMap.put("chats", chatList);
          return resultMap;
    } 
+   
+   
+   public String formatTimestamp(Timestamp ts) {
+	    if (ts == null) return "";
+	    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+	    return sdf.format(ts);
+	}
+
+   
    
    public List<ChaListProfileImageDTO> selectChatRoomListWithProfile(Map<String, Object> map) {
 	   System.out.println("userId: " + map.get("userId"));


### PR DESCRIPTION
1. 문제 상황
서비스에서 채팅 메시지의 chatCreatedAt(메시지 생성 시간)을
채팅방 목록 및 알림 UI에 표시할 때
서버와 클라이언트 간 데이터 포맷 불일치로 인해
다음과 같은 이슈가 발생했다.

어떤 화면(A)에서는 yyyy-MM-dd hh:mm:ss 형식으로 잘 나오지만,
다른 화면(B)에서는 yyyy-MM-ddThh:mm:ss.~~~+09:00(ISO8601 포맷) 형식으로 노출되어 가독성이 떨어지고, 일관성이 깨지는 문제가 있었다.
화면별로 시간 표시 방식이 다르거나, 일부 최신 브라우저에서만 정상적으로 파싱되는 현상이 있었음.
이 문제의 원인은

서버에서 내려주는 chatCreatedAt 값이
숫자(timestamp, 예: 1756341250000)
ISO8601 문자열(예: "2025-08-28T10:39:42.881+09:00")
혼합되어 내려오고 있었으며
프론트 JS 코드가 이를 일관되게 사람이 읽기 쉬운 형식으로 변환하지 못함에 있었다.
2. 문제 분석
브라우저의 Date 객체는 다양한 포맷을 지원하지만,
+09:00 타임존이 붙은 ISO 문자열은 브라우저별 파싱 차이가 있음
숫자(timestamp)는 항상 UTC 기준으로 파싱
기존 코드에서는
숫자(timestamp)만 처리하거나
ISO 포맷은 그대로 출력해서 사용자 경험에 불편을 초래
3. 코드적 해결 과정 및 논리
A. 일관된 포맷 변환 함수 구현
클라이언트에서 시간 변환 함수(formatTimestamp)를 구현
입력값이 숫자(timestamp), ISO 문자열, 둘 다 올 수 있도록 분기
ISO 포맷에서 브라우저가 파싱하지 못하는 경우(+09:00)는
→ Z로 치환해 강제 파싱
파싱 후에는 항상 yyyy-MM-dd hh:mm:ss 형식으로 문자열을 만들어 반환
JavaScript
function formatTimestamp(ts) {
    if (!ts) return '';
    let date;
    if (typeof ts === 'number' || /^\d+$/.test(ts)) {
        date = new Date(Number(ts));
    } else if (typeof ts === 'string') {
        date = new Date(ts);
        if (isNaN(date.getTime()) && ts.includes('+09:00')) {
            date = new Date(ts.replace('+09:00', 'Z'));
        }
    } else {
        return '';
    }
    if (isNaN(date.getTime())) return '';

    var yyyy = date.getFullYear();
    var mm = String(date.getMonth() + 1).padStart(2, '0');
    var dd = String(date.getDate()).padStart(2, '0');
    var hh = String(date.getHours()).padStart(2, '0');
    var min = String(date.getMinutes()).padStart(2, '0');
    var ss = String(date.getSeconds()).padStart(2, '0');
    return yyyy + '-' + mm + '-' + dd + ' ' + hh + ':' + min + ':' + ss;
}
B. 모든 시간 표시 영역에 적용
채팅방 목록, 알림, 메시지 내역 등 시간 표시가 필요한 모든 영역에 해당 함수로 변환해서 출력
기존의 시간 데이터가 어떤 포맷이든, 일관적으로 사람이 읽기 좋은 형식으로 보여주어 UI/UX의 통일성 확보
JavaScript
var timeText = formatTimestamp(chatCreatedAt);
timeSpan.textContent = timeText;
4. 결과 및 개선 효과
모든 사용자(A/B), 모든 화면에서
chatCreatedAt이 항상 yyyy-MM-dd hh:mm:ss 포맷으로 표시됨
브라우저별, 서버/클라이언트 환경별 시간 표시 불일치 문제가 완벽하게 해결됨
코드 유지보수성과 확장성이 향상됨
(향후 다른 포맷이 추가되어도 formatTimestamp 함수만 수정하면 됨)
UI/UX 일관성 확보, 사용자 경험 개선