### PR TITLE
채팅방 목록 페이지에서 판매자/구매자 알려주기 및 채팅방 나가기 기능 추가

### DIFF
--- a/puppit/pom.xml
+++ b/puppit/pom.xml
@@ -41,6 +41,12 @@
     <version>${spring.version}</version>
 </dependency>
 <dependency>
+    <groupId>jakarta.servlet</groupId>
+    <artifactId>jakarta.servlet-api</artifactId>
+    <version>6.0.0</version>
+    <scope>provided</scope>
+</dependency>
+<dependency>
     <groupId>org.springframework</groupId>
     <artifactId>spring-websocket</artifactId>
     <version>${spring.version}</version>

--- a/puppit/src/main/java/org/puppit/controller/ChatApiAlarmController.java
+++ b/puppit/src/main/java/org/puppit/controller/ChatApiAlarmController.java
@@ -115,16 +115,7 @@ public class ChatApiAlarmController {
 	    return result;
 	}
 	
-//	@GetMapping(value = "/chat/countBuyerToSeller", produces = MediaType.APPLICATION_JSON_VALUE)
-//	@ResponseBody
-//	public Map<String, Integer> getBuyerToSellerCount(@RequestParam("roomId") int roomId,
-//	                                                 @RequestParam("buyerId") int buyerId,
-//	                                                 @RequestParam("sellerId") int sellerId) {
-//	    int count = chatService.getBuyerToSellerCount(roomId, buyerId, sellerId);
-//	    Map<String, Integer> result = new HashMap<>();
-//	    result.put("buyerToSellerCount", count);
-//	    return result;
-//	}
+
 	
 	
 	

--- a/puppit/src/main/java/org/puppit/controller/ChatController.java
+++ b/puppit/src/main/java/org/puppit/controller/ChatController.java
@@ -125,6 +125,7 @@ public class ChatController {
 
 	    // 사용 예시
 	    System.out.println("lastMessageAt = " + lastMessageAt);
+	    System.out.println("chats: " + chatMap.get("chats"));
 	    model.addAttribute("chatList", chatMap.get("chats"));
 	    model.addAttribute("profileImage", chatMap.get("profileImage"));
 	    model.addAttribute("highlightRoomId", highlightRoomId);
@@ -138,6 +139,20 @@ public class ChatController {
 	public Integer readAlarm(@RequestParam("messageId") Integer messageId) {
 		// 변경된 행 수를 리턴
         return chatAlarmService.readAlarm(messageId);
+	}
+	
+	@PostMapping(value = "/removeroom",  produces = MediaType.APPLICATION_JSON_VALUE)
+	@ResponseBody
+	public Map<String, Object> removeRoom(@RequestParam("roomId") int roomId) {
+	   Map<String, Object> result = new HashMap<>();
+	   try {
+	        chatService.removeRoomCascade(roomId);
+	        result.put("success", true);
+	    } catch (Exception e) {
+	        result.put("success", false);
+	        result.put("message", e.getMessage());
+	    }
+	    return result;
 	}
 	
 	

--- a/puppit/src/main/java/org/puppit/model/dto/ChatListDTO.java
+++ b/puppit/src/main/java/org/puppit/model/dto/ChatListDTO.java
@@ -9,7 +9,6 @@ import lombok.Setter;
 import lombok.ToString;
 
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter
 @Setter
 @ToString
@@ -21,6 +20,8 @@ public class ChatListDTO {
 	private Integer sellerId;
 	private String sellerName;
 	private String sellerAccountId;
+	private String sellerNickName;
+	private String buyerNickName;
 	private Integer otherUserId;
 	private String otherAccountId;
 	private String otherUserName;
@@ -35,6 +36,8 @@ public class ChatListDTO {
 	private Timestamp lastMessageAt; // 마지막 메시지 생성 시간 추가
 	private String otherProfileImageKey;
 	private String chatLastMessageAt;
+	
+	
 
 	
 }

--- a/puppit/src/main/java/org/puppit/repository/ChatDAO.java
+++ b/puppit/src/main/java/org/puppit/repository/ChatDAO.java
@@ -212,6 +212,20 @@ public int getBuyerToSellerCount(int roomId, int buyerId, int sellerId) {
     return count != null ? count : 0;
 }
 
+public void deleteChatsByRoomId(int roomId) {
+	sqlSession.delete( "mybatis.mapper.chatMapper.deleteChatsByRoomId", roomId);
+    
+}
+
+
+public void deleteRoom(int roomId) {
+	 sqlSession.delete("mybatis.mapper.chatMapper.deleteRoom", roomId);
+   
+}
+
+public void deleteAlarmsByRoomId(int roomId) {
+	sqlSession.delete("mybatis.mapper.chatMapper.deleteAlarmsByRoomId", roomId);
+}
 
    
    

--- a/puppit/src/main/java/org/puppit/service/ChatService.java
+++ b/puppit/src/main/java/org/puppit/service/ChatService.java
@@ -43,4 +43,5 @@ public interface ChatService {
     int isAlarmDuplicate(NotificationDTO notification);
 	public int getTotalChatCount(int roomId, int buyerId, int sellerId);
 	public int getBuyerToSellerCount(int roomId, int buyerId, int sellerId);
+	public void removeRoomCascade(int roomId) throws Exception;
 }

--- a/puppit/src/main/java/org/puppit/service/ChatServiceImpl.java
+++ b/puppit/src/main/java/org/puppit/service/ChatServiceImpl.java
@@ -184,5 +184,15 @@ public class ChatServiceImpl implements ChatService{
 	    return chatDAO.getBuyerToSellerCount(roomId, buyerId, sellerId);
 	}
 
+	@Override
+	@Transactional
+	public void removeRoomCascade(int roomId) throws Exception {
+		// 1. 자식(alarm) 먼저 삭제
+		chatDAO.deleteAlarmsByRoomId(roomId);
+	    // 2. 자식(chat) 먼저 삭제
+	    chatDAO.deleteChatsByRoomId(roomId);
+	    // 3. 부모(room) 삭제
+	    chatDAO.deleteRoom(roomId);
+	}
 
 }

--- a/puppit/src/main/resources/mybatis/config/mybatis-config.xml
+++ b/puppit/src/main/resources/mybatis/config/mybatis-config.xml
@@ -4,10 +4,9 @@
   "http://mybatis.org/dtd/mybatis-3-config.dtd" >
 <configuration>
   
-  <!--  마이바이티스 환경 설정 (snake_case To camelCase) -->
-  <settings>
-    <setting name="mapUnderscoreToCamelCase" value="true"/>
-  </settings>
+ <settings>
+  <setting name="mapUnderscoreToCamelCase" value="true"/>
+</settings>
   
   <!-- 클래스에 별명 등록 (DTO) -->
   <typeAliases>

--- a/puppit/src/main/resources/mybatis/mapper/chatMapper.xml
+++ b/puppit/src/main/resources/mybatis/mapper/chatMapper.xml
@@ -4,46 +4,82 @@
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="mybatis.mapper.chatMapper">
   
+<resultMap id="ChatListMap" type="org.puppit.model.dto.ChatListDTO">
+    <result property="roomId" column="roomId"/>
+    <result property="productId" column="productId"/>
+    <result property="productName" column="productName"/>
+    <result property="productPrice" column="productPrice"/>
+    <result property="sellerId" column="sellerId"/>
+    <result property="sellerName" column="sellerName"/>
+    <result property="sellerAccountId" column="sellerAccountId"/>
+    <result property="sellerNickName" column="sellerNickName"/>
+    <result property="buyerNickName" column="buyerNickName"/>
+    <result property="otherUserId" column="otherUserId"/>
+    <result property="otherAccountId" column="otherAccountId"/>
+    <result property="otherUserName" column="otherUserName"/>
+    <result property="lastMessage" column="lastMessage"/>
+    <result property="lastMessageSenderId" column="lastMessageSenderId"/>
+    <result property="lastMessageSenderAccountId" column="lastMessageSenderAccountId"/>
+    <result property="lastMessageSenderName" column="lastMessageSenderName"/>
+    <result property="lastMessageReceiverId" column="lastMessageReceiverId"/>
+    <result property="lastMessageReceiverAccountId" column="lastMessageReceiverAccountId"/>
+    <result property="lastMessageReceiverName" column="lastMessageReceiverName"/>
+    <result property="sortTime" column="sortTime"/>
+    <result property="lastMessageAt" column="lastMessageAt"/>
+    <result property="otherProfileImageKey" column="otherProfileImageKey"/>
+    <result property="chatLastMessageAt" column="chatLastMessageAt"/>
+</resultMap>  
+  
+  
 <!-- 내가 로그인 해서 내가 채팅한 모든 사용자들과의 마지막 메시지만 불러오는 코드 -->  
-<select id="getChatList" resultType="org.puppit.model.dto.ChatListDTO">
-    SELECT
-    r.room_id                  AS roomId,
-    p.product_id               AS productId,
-    p.product_name             AS productName,
-    p.product_price            AS productPrice,
-    -- 상대방 정보 (내가 sender면 receiver, 내가 receiver면 sender)
-    CASE
-        WHEN c.chat_sender = #{userId} THEN receiver.user_id
-        ELSE sender.user_id
-    END                        AS otherUserId,
-    CASE
-        WHEN c.chat_sender = #{userId} THEN receiver.account_id
-        ELSE sender.account_id
-    END                        AS otherAccountId,
-    CASE
-        WHEN c.chat_sender = #{userId} THEN receiver.user_name
-        ELSE sender.user_name
-    END                        AS otherUserName,
-    -- 마지막 메시지 정보
-    c.chat_message             AS lastMessage,
-    c.chat_created_at          AS lastMessageAt,
-    c.chat_sender              AS lastMessageSenderId,
-    sender.account_id          AS lastMessageSenderAccountId,
-    sender.user_name           AS lastMessageSenderName,
-    c.chat_receiver            AS lastMessageReceiverId,
-    receiver.account_id        AS lastMessageReceiverAccountId,
-    receiver.user_name         AS lastMessageReceiverName
+<select id="getChatList" resultMap="ChatListMap">
+
+
+SELECT
+  r.room_id                  AS roomId,
+  p.product_id               AS productId,
+  p.product_name             AS productName,
+  p.product_price            AS productPrice,
+  -- 상대방 정보 (내가 sender면 receiver, 내가 receiver면 sender)
+  CASE
+      WHEN c.chat_sender = #{userId} THEN receiver.user_id
+      ELSE sender.user_id
+  END                        AS otherUserId,
+  CASE
+      WHEN c.chat_sender = #{userId} THEN receiver.account_id
+      ELSE sender.account_id
+  END                        AS otherAccountId,
+  CASE
+      WHEN c.chat_sender = #{userId} THEN receiver.user_name
+      ELSE sender.user_name
+  END                        AS otherUserName,
+  -- 구매자 닉네임
+  buyer.nick_name            AS buyerNickName,
+  -- 판매자 닉네임 추가!
+  seller.nick_name           AS sellerNickName,
+  -- 마지막 메시지 정보
+  c.chat_message             AS lastMessage,
+  c.chat_created_at          AS lastMessageAt,
+  c.chat_sender              AS lastMessageSenderId,
+  sender.account_id          AS lastMessageSenderAccountId,
+  sender.user_name           AS lastMessageSenderName,
+  c.chat_receiver            AS lastMessageReceiverId,
+  receiver.account_id        AS lastMessageReceiverAccountId,
+  receiver.user_name         AS lastMessageReceiverName
 FROM (
-    SELECT chat_room_id, MAX(message_id) AS max_message_id
-    FROM chat
-    WHERE chat_sender = #{userId} OR chat_receiver = #{userId}
-    GROUP BY chat_room_id
+  SELECT chat_room_id, MAX(message_id) AS max_message_id
+  FROM chat
+  WHERE chat_sender = #{userId} OR chat_receiver = #{userId}
+  GROUP BY chat_room_id
 ) last_msg
 JOIN chat c ON c.chat_room_id = last_msg.chat_room_id AND c.message_id = last_msg.max_message_id
 JOIN room r ON c.chat_room_id = r.room_id
 JOIN product p ON r.product_id = p.product_id
 JOIN user sender ON c.chat_sender = sender.user_id
 JOIN user receiver ON c.chat_receiver = receiver.user_id
+JOIN user buyer ON r.user_id = buyer.user_id
+
+JOIN user seller ON p.seller_id = seller.user_id
 ORDER BY c.chat_created_at DESC
 </select>
   
@@ -67,39 +103,49 @@ ORDER BY c.chat_created_at DESC
 	</select>
   
   
- <select id="getChatMyProfileImage" parameterType="String"  resultType="org.puppit.model.dto.ChaListProfileImageDTO">
+ <select id="getChatMyProfileImage" parameterType="map"  resultType="org.puppit.model.dto.ChaListProfileImageDTO">
   	  SELECT
-    c.chat_room_id,
-    p.product_name,
-    c.chat_message,
-    sender.account_id AS chat_sender_account_id,
-    receiver.account_id AS chat_receiver_account_id,
-    sender.profile_image_key AS senderProfileImageKey,
-    receiver.profile_image_key AS receiverProfileImageKey,
-    p.seller_id AS product_seller_id,
-    seller.account_id AS product_seller_account_id,
-    seller.profile_image_key AS sellerProfileImageKey,
-    -- 상대방 프로필 이미지 키 (로그인 계정 기준)
-    CASE 
-        WHEN #{accountId} = sender.account_id THEN receiver.profile_image_key
-        WHEN #{accountId} = receiver.account_id THEN sender.profile_image_key
-        ELSE NULL
-    END AS otherProfileImageKey
-FROM chat c
-INNER JOIN room r ON c.chat_room_id = r.room_id
-INNER JOIN product p ON r.product_id = p.product_id
-LEFT JOIN user sender ON c.chat_sender = sender.user_id
-LEFT JOIN user receiver ON c.chat_receiver = receiver.user_id
-LEFT JOIN user seller ON p.seller_id = seller.user_id
-WHERE sender.account_id = #{accountId}
-   OR receiver.account_id = #{accountId}
-ORDER BY c.chat_created_at DESC
+        r.room_id AS chat_room_id,
+        p.product_name,
+        c.chat_message,
+        sender.user_id AS chat_sender_user_id,
+        receiver.user_id AS chat_receiver_user_id,
+        sender.profile_image_key AS senderProfileImageKey,
+        receiver.profile_image_key AS receiverProfileImageKey,
+        p.seller_id AS product_seller_id,
+        seller.user_id AS product_seller_user_id,
+        seller.profile_image_key AS sellerProfileImageKey,
+        CASE 
+            WHEN #{userId} = sender.user_id THEN receiver.profile_image_key
+            WHEN #{userId} = receiver.user_id THEN sender.profile_image_key
+            ELSE seller.profile_image_key
+        END AS otherProfileImageKey
+    FROM room r
+    INNER JOIN product p ON r.product_id = p.product_id
+    LEFT JOIN chat c ON r.room_id = c.chat_room_id
+    LEFT JOIN user sender ON c.chat_sender = sender.user_id
+    LEFT JOIN user receiver ON c.chat_receiver = receiver.user_id
+    LEFT JOIN user seller ON p.seller_id = seller.user_id
+    WHERE
+        r.user_id = #{userId}
+        OR p.seller_id = #{userId}
+    ORDER BY c.chat_created_at DESC, r.room_created_at DESC
   
   
   </select>
   
-  
-  
+     <!-- chat 테이블의 해당 roomId 대화 모두 삭제 -->
+    <delete id="deleteChatsByRoomId" parameterType="int">
+        DELETE FROM chat WHERE chat_room_id = #{roomId}
+    </delete>
+    <!-- room 테이블에서 방 삭제 -->
+    <delete id="deleteRoom" parameterType="int">
+        DELETE FROM room WHERE room_id = #{roomId}
+    </delete>
+  <!-- roomId에 해당하는 alarm 전체 삭제 -->
+<delete id="deleteAlarmsByRoomId" parameterType="int">
+    DELETE FROM alarm WHERE room_id = #{roomId}
+</delete>
   
   
 </mapper>

--- a/puppit/src/main/resources/mybatis/mapper/chatMessageMapper.xml
+++ b/puppit/src/main/resources/mybatis/mapper/chatMessageMapper.xml
@@ -173,49 +173,51 @@ ORDER BY c.chat_created_at ASC;
   
 <select id="getChatRoomsByCreatedDesc" resultType="org.puppit.model.dto.ChatListDTO" parameterType="map">
  SELECT 
-            r.room_id                  AS roomId,
-            r.product_id               AS productId,
-            p.product_name             AS productName,
-            p.product_price            AS productPrice,
-            p.seller_id                AS sellerId,
-            s.nick_name               AS sellerAccountId,
-            u.user_name                AS buyerName,
-            s.user_name                AS sellerName,
-            last_msg.chat_message      AS lastMessage,
-            last_msg.chat_created_at   AS lastMessageAt,
-            last_msg.chat_sender       AS lastMessageSenderId,
-            sender.nick_name          AS lastMessageSenderAccountId,
-            sender.user_name           AS lastMessageSenderName,
-            last_msg.chat_receiver     AS lastMessageReceiverId,
-            receiver.nick_name        AS lastMessageReceiverAccountId,
-            receiver.user_name         AS lastMessageReceiverName,
-            COALESCE(last_msg.chat_created_at, r.room_created_at) AS sortTime
-        FROM room r
-        JOIN product p ON r.product_id = p.product_id
-        JOIN user u ON r.user_id = u.user_id
-        JOIN user s ON p.seller_id = s.user_id
-        LEFT JOIN (
-            SELECT c1.*
-            FROM chat c1
-            INNER JOIN (
-                SELECT chat_room_id, MAX(chat_created_at) AS max_created_at
-                FROM chat
-                GROUP BY chat_room_id
-            ) c2
-            ON c1.chat_room_id = c2.chat_room_id AND c1.chat_created_at = c2.max_created_at
-        ) last_msg ON r.room_id = last_msg.chat_room_id
-        LEFT JOIN user sender ON last_msg.chat_sender = sender.user_id
-        LEFT JOIN user receiver ON last_msg.chat_receiver = receiver.user_id
-        WHERE
-              r.user_id = #{userId}
-           OR p.seller_id = #{userId}
-           OR EXISTS (
-                SELECT 1
-                FROM chat c2
-                WHERE c2.chat_room_id = r.room_id
-                  AND (c2.chat_sender = #{userId} OR c2.chat_receiver = #{userId})
-           )
-        ORDER BY sortTime DESC
+        r.room_id                  AS roomId,
+        r.product_id               AS productId,
+        p.product_name             AS productName,
+        p.product_price            AS productPrice,
+        p.seller_id                AS sellerId,
+        s.nick_name                AS sellerAccountId,
+        s.nick_name                AS sellerNickName,
+        u.user_name                AS buyerName,
+        u.nick_name                AS buyerNickName,
+        s.user_name                AS sellerName,
+        last_msg.chat_message      AS lastMessage,
+        last_msg.chat_created_at   AS lastMessageAt,
+        last_msg.chat_sender       AS lastMessageSenderId,
+        sender.nick_name           AS lastMessageSenderAccountId,
+        sender.user_name           AS lastMessageSenderName,
+        last_msg.chat_receiver     AS lastMessageReceiverId,
+        receiver.nick_name         AS lastMessageReceiverAccountId,
+        receiver.user_name         AS lastMessageReceiverName,
+        COALESCE(last_msg.chat_created_at, r.room_created_at) AS sortTime
+    FROM room r
+    JOIN product p ON r.product_id = p.product_id
+    JOIN user u ON r.user_id = u.user_id
+    JOIN user s ON p.seller_id = s.user_id
+    LEFT JOIN (
+        SELECT c1.*
+        FROM chat c1
+        INNER JOIN (
+            SELECT chat_room_id, MAX(chat_created_at) AS max_created_at
+            FROM chat
+            GROUP BY chat_room_id
+        ) c2
+        ON c1.chat_room_id = c2.chat_room_id AND c1.chat_created_at = c2.max_created_at
+    ) last_msg ON r.room_id = last_msg.chat_room_id
+    LEFT JOIN user sender ON last_msg.chat_sender = sender.user_id
+    LEFT JOIN user receiver ON last_msg.chat_receiver = receiver.user_id
+    WHERE
+          r.user_id = #{userId}
+       OR p.seller_id = #{userId}
+       OR EXISTS (
+            SELECT 1
+            FROM chat c2
+            WHERE c2.chat_room_id = r.room_id
+              AND (c2.chat_sender = #{userId} OR c2.chat_receiver = #{userId})
+       )
+    ORDER BY sortTime DESC
 </select>  
 
  <!-- roomId를 기반으로 productId만 조회 -->

--- a/puppit/src/main/webapp/WEB-INF/views/chat/list.jsp
+++ b/puppit/src/main/webapp/WEB-INF/views/chat/list.jsp
@@ -335,6 +335,69 @@ style.innerHTML = `
   font-weight:700;
 }
 
+#chatListRenderArea {
+    margin: 0;
+    padding: 0;
+}
+.chatList {
+    display: flex;
+    align-items: flex-start;
+    margin-bottom: 18px;
+    cursor: pointer;
+}
+.chat-profile-img {
+    width: 48px;
+    height: 48px;
+    margin-right: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.chat-profile-img img {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 1px solid #ccc;
+}
+.chat-info-wrap {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+}
+.chat-user-row {
+    font-weight: bold;
+    font-size: 18px;
+    margin-bottom: 2px;
+}
+.chat-user-row .chat-role {
+    font-size: 14px;
+    font-weight: normal;
+    margin-left: 3px;
+    color: #666;
+}
+.chat-message-row {
+    font-size: 16px;
+    margin-bottom: 2px;
+    color: #222;
+    word-break: break-all;
+}
+.chat-meta-row {
+    font-size: 13px;
+    color: #888;
+}
+.unread-badge {
+    background: #e74c3c;
+    color: #fff;
+    font-size: 13px;
+    font-weight: bold;
+    border-radius: 10px;
+    padding: 3px 7px;
+    margin-left: 8px;
+    vertical-align: middle;
+    display: none;
+}
+
 
     </style>
 </head>
@@ -369,14 +432,16 @@ style.innerHTML = `
                     </span>
                     <div class="chat-info-area" style="cursor:pointer;">
                         <div class="chat-nickname">
-                             <c:choose>
-                                <c:when test="${not empty chat.productName}">
-                                    <c:out value="${chat.productName}" />  (<c:out value="${chat.sellerAccountId}" />)
-                                </c:when>
-                                <c:otherwise>
-                                    상품판매자와 채팅을 시작해보세요
-                                </c:otherwise>
-                            </c:choose>
+                        	<div class="chat-nickname">
+							    		<c:out value="${chat.productName}"/> /	
+							            <c:out value="${chat.sellerAccountId}" /> (판매자) /
+							            <c:out value="${chat.buyerNickName}" /> (구매자)
+							       
+							</div>
+                        
+                        
+                            
+                               
                         </div>
                          
                         <div class="chat-message">
@@ -449,6 +514,15 @@ document.addEventListener('DOMContentLoaded', function() {
 	  if (isLoggedIn === "true" && isChatListPage) {
 	        loadUnreadCounts();
 	  }
+	  
+	  document.body.addEventListener('click', function(e) {
+	        if (e.target && e.target.id === 'chat-options-btn') {
+	            showOptionsPopup(e.target);
+	        }
+	    });
+	  
+	  
+	  
 	  	// 1. 로그인 성공시 내가 안읽은 메시지 전부 알림팝업에 띄우기
       // (sessionScope.sessionMap.accountId 방식의 로그인 체크)
      
@@ -702,43 +776,253 @@ Promise.all(chatCountPromises).then(() => {
     
    
     
-  //안내 모달 생성 함수
-    function showExitChatroomModal() {
-      // 이미 있으면 제거
-      const oldModal = document.getElementById('exit-chatroom-modal-bg');
-      if (oldModal) oldModal.remove();
-      const modalBg = document.createElement('div');
-      modalBg.id = 'exit-chatroom-modal-bg';
-      modalBg.innerHTML = `
-        <div id="exit-chatroom-modal">
-          <button class="close-btn" title="닫기">&times;</button>
-          <div class="exit-text">채팅방을 나가면 복구할 수 없습니다.<br>정말 나가시겠습니까?</div>
-          <button class="confirm-btn">확인</button>
-        </div>
-      `;
-      document.body.appendChild(modalBg);
-    }
 
-    // 삭제 완료 팝업 생성 함수
-    function showExitDonePopup() {
-      // 이미 있으면 제거
-      const oldPopup = document.getElementById('exit-chatroom-done');
-      if (oldPopup) oldPopup.remove();
-      const donePopup = document.createElement('div');
-      donePopup.id = 'exit-chatroom-done';
-      donePopup.innerHTML = `
-        <button class="close-btn" title="닫기">&times;</button>
-        <div>채팅방이 삭제되었습니다.</div>
-      `;
-      document.body.appendChild(donePopup);
-      // 2초 후 자동 close
-      setTimeout(() => {
-        const popup = document.getElementById('exit-chatroom-done');
-        if (popup) popup.remove();
-      }, 2000);
-    }
+
+   
     
-});
+}); //DOM끝
+
+
+//팝업 생성/삭제 함수
+function showOptionsPopup(anchorElem) {
+    // 이미 있으면 제거
+    const old = document.getElementById('chat-options-popup');
+    if (old) old.remove();
+    // 팝업 생성
+    const popup = document.createElement('div');
+    popup.id = 'chat-options-popup';
+    popup.style.display = 'block';
+    popup.style.position = 'absolute';
+    popup.style.right = '0';
+    popup.style.top = '38px';
+    popup.style.background = '#fff';
+    popup.style.border = '1px solid #bbb';
+    popup.style.borderRadius = '8px';
+    popup.style.minWidth = '220px';
+    popup.style.minHeight = '50px';
+    popup.style.zIndex = '99999';
+    popup.innerHTML = `
+        <div class="chat-option-item" id="exit-chatroom-btn" style="background:#e74c3c;color:#fff;border-radius:8px;font-size:15px;font-weight:700;margin-bottom:2px;cursor:pointer;">채팅방 나가기</div>
+    `;
+    anchorElem.parentNode.appendChild(popup);
+
+    // 나가기 버튼 클릭 이벤트
+    popup.querySelector('#exit-chatroom-btn').onclick = function(e) {
+        popup.remove();
+        showExitChatroomModal();
+    };
+
+    // 외부 클릭시 닫기
+    setTimeout(() => {
+        document.addEventListener('mousedown', function handler(ev) {
+            if (!popup.contains(ev.target) && ev.target !== anchorElem) {
+                popup.remove();
+                document.removeEventListener('mousedown', handler);
+            }
+        });
+    }, 30);
+}
+
+//첫번째 팝업(정말 나가시겠습니까?)
+function showExitChatroomModal() {
+    removeModalById('exit-chatroom-modal-bg');
+    const modalBg = document.createElement('div');
+    modalBg.className = 'custom-modal-bg';
+    modalBg.id = 'exit-chatroom-modal-bg';
+    modalBg.innerHTML = `
+        <div class="custom-modal">
+            <button class="close-btn" title="닫기">&times;</button>
+            <div class="exit-text">정말 채팅방을 나가시겠습니까?<br>대화내용을 복구할 수 없습니다.</div>
+            <button class="confirm-btn">확인</button>
+        </div>
+    `;
+    document.body.appendChild(modalBg);
+
+    modalBg.querySelector('.close-btn').onclick = () => modalBg.remove();
+    modalBg.querySelector('.confirm-btn').onclick = function() {
+        modalBg.remove();
+        // --- 실제 삭제 요청 ---
+        fetch(contextPath + '/chat/removeroom?roomId=' + currentRoomId, {
+            method: 'POST'
+        })
+        .then(res => res.json())
+        .then(data => {
+            console.log('삭제 결과:', data);
+            if (data.success) {
+                showExitDonePopup().then(() => {
+                    // 팝업이 사라진 후에 리스트 리로드!!
+                    reloadRecentRoomList();
+                });
+            } else {
+                alert('삭제 실패: ' + (data.message || ''));
+            }
+        })
+        .catch(err => {
+            alert('삭제 중 오류 발생: ' + err);
+        });
+    };
+}
+
+//두번째 팝업(나가기 완료)
+function showExitDonePopup() {
+    return new Promise((resolve) => {
+        removeModalById('exit-chatroom-done-bg');
+        const doneBg = document.createElement('div');
+        doneBg.className = 'custom-modal-bg';
+        doneBg.id = 'exit-chatroom-done-bg';
+        doneBg.style.position = 'fixed';   // ← 반드시 fixed
+        doneBg.style.top = '50%';
+        doneBg.style.left = '50%';
+        doneBg.style.transform = 'translate(-50%, -50%)';
+        doneBg.style.zIndex = '999999';    // ← z-index 높게!
+        doneBg.innerHTML = `
+            <div class="custom-modal">
+                <button class="close-btn" title="닫기">&times;</button>
+                <div class="exit-text">채팅방 나가기 되었습니다.</div>
+            </div>
+        `;
+        document.body.appendChild(doneBg);
+
+        setTimeout(() => {
+            doneBg.remove();
+            resolve();
+        }, 2000);
+
+        doneBg.querySelector('.close-btn').onclick = () => {
+            doneBg.remove();
+            resolve();
+        };
+    });
+}
+
+function reloadRecentRoomList() {
+    const defaultImg = contextPath + '/resources/image/profile-default.png';
+    fetch(contextPath + '/api/chat/recentRoomList')
+        .then(res => res.json())
+        .then(data => {
+            const chatListRenderArea = document.getElementById('chatListRenderArea');
+            if (!chatListRenderArea) return;
+            chatListRenderArea.innerHTML = '';
+
+            const chats = Array.isArray(data.chats) ? data.chats : [];
+            const profileImages = Array.isArray(data.profileImage) ? data.profileImage : [];
+
+            chats.forEach(chat => {
+                // profileImage 배열에서 해당 roomId에 맞는 이미지 정보 찾기
+                let imgSrc = defaultImg;
+                const profileInfo = profileImages.find(pi => String(pi.chatRoomId) === String(chat.roomId));
+                if (profileInfo && profileInfo.sellerProfileImageKey) {
+                    imgSrc = 'https://jscode-upload-images.s3.ap-northeast-2.amazonaws.com/' + profileInfo.sellerProfileImageKey;
+                }
+
+                // 닉네임/계정ID (예시: 슈퍼감찬)
+                const sellerName = chat.sellerAccountId || chat.sellerName || '';
+                const sellerRole = '(판매자)';
+
+                // 마지막 메시지
+                const lastMsg = chat.lastMessage || '';
+                // 마지막 메시지 시간
+                const lastMsgTime = chat.chatLastMessageAt || '';
+                const buyerName = chat.buyerNickName || chat.buyerName || ''; // 구매자 닉네임
+                const buyerRole = '(구매자)';
+               
+              
+                
+                
+                const html =
+                	'<div class="chatList">' +
+                    '<span class="chat-profile-img">' +
+                        '<img src="' + imgSrc + '" alt="프로필 이미지" onerror="this.src=\'' + defaultImg + '\'"/>' +
+                    '</span>' +
+                    '<div class="chat-info-wrap">' +
+                        '<div class="chat-user-row">' +
+                            '<span class="chat-user-seller">' + sellerName + ' <span class="chat-role">' + sellerRole + '</span></span> / ' +
+                            '<span class="chat-user-buyer">' + buyerName + ' <span class="chat-role">' + buyerRole + '</span></span>' +
+                        '</div>' +
+                        '<div class="chat-message-row">' +
+                            lastMsg +
+                        '</div>' +
+                        '<div class="chat-meta-row">' +
+                            lastMsgTime +
+                        '</div>' +
+                    '</div>' +
+                    '<span class="unread-badge"></span>' +
+                '</div>';
+
+                chatListRenderArea.insertAdjacentHTML('beforeend', html);
+            });
+
+            // 이벤트 바인딩 (각 .chatList)
+            chatListRenderArea.querySelectorAll('.chatList').forEach(function(chatDiv, idx) {
+                chatDiv.dataset.roomId = chats[idx].roomId;
+                chatDiv.addEventListener('click', function(e) {
+                    const roomId = chatDiv.dataset.roomId;
+                    selectedRoomId = roomId;
+                    currentRoomId = roomId;
+                    document.querySelectorAll('.chatList').forEach(el => el.classList.remove('highlight', 'selected'));
+                    chatDiv.classList.add('highlight', 'selected');
+                    if (highlightTimers[roomId]) clearTimeout(highlightTimers[roomId]);
+                    highlightTimers[roomId] = setTimeout(() => {
+                        chatDiv.classList.remove('highlight');
+                        highlightTimers[roomId] = null;
+                    }, 2000);
+
+                    showChatUI();
+                    chatHistory.innerHTML = "";
+                    renderedMessageIds.clear();
+                    loadChatHistory(roomId).then(() => {
+                        connectAndSubscribe(roomId);
+                    });
+
+                    // 읽음 처리 + 뱃지 제거
+                    const badge = chatDiv.querySelector('.unread-badge');
+                    const unreadCount = badge && badge.style.display !== 'none' ? parseInt(badge.textContent) || 0 : 0;
+                    if (unreadCount > 0) {
+                        fetch(contextPath + '/api/alarm/readAll', {
+                            method: 'POST',
+                            headers: {'Content-Type': 'application/json'},
+                            body: JSON.stringify({
+                                roomId: roomId,
+                                userId: userId,
+                                count: unreadCount
+                            })
+                        })
+                        .then(res => res.json())
+                        .then(data => {
+                            badge.style.display = 'none';
+                            badge.textContent = '';
+                            if (window.removeAlarmPopupRoom) window.removeAlarmPopupRoom(roomId);
+                        })
+                        .catch(err => {
+                            console.error('안읽은 메시지 읽음 처리 에러:', err);
+                        });
+                    }
+                });
+            });
+
+            // 뱃지 업데이트
+            if (typeof updateUnreadBadges === 'function') {
+                fetch(contextPath + '/api/chat/unreadCount?userId=' + userId)
+                    .then(res => res.json())
+                    .then(unreadCounts => {
+                        updateUnreadBadges(unreadCounts);
+                    });
+            }
+        })
+        .catch(err => {
+            console.error('채팅방 목록 재요청 에러:', err);
+        });
+}
+
+
+
+//중복 제거 함수
+function removeModalById(id) {
+    const elem = document.getElementById(id);
+    if (elem) elem.remove();
+    console.log('id: ', id);
+}
+
 
 /* [추가] 채팅 UI show/hide 함수 */
 function showChatUI(isRoomSelected=true) {
@@ -1456,6 +1740,8 @@ function updateChatListLastMessage(roomId, chatMessage, chatCreatedAt) {
 
 
 //window에 등록
+window.showExitDonePopup = showExitDonePopup;
+window.showExitChatroomModal = showExitChatroomModal; // window에 등록
 window.highlightChatRoom = highlightChatRoom;
 window.updateChatListLastMessage = updateChatListLastMessage;
 window.displayNotification = displayNotification;


### PR DESCRIPTION
Copilot said: 네, 아래는 "채팅방 나가기 기능 및 팝업
네, 아래는 "채팅방 나가기 기능 및 팝업 UI 동기 처리"에 대해
문제 → 원인 분석 → 기술적 해결 → 선택한 방식의 논리적 이유를 포트폴리오용으로 정리한 예시입니다.

1. 문제 상황
채팅방에서 "나가기" 버튼을 누르면, 삭제 성공 이후 안내 팝업(“채팅방 나가기 되었습니다”)이 정상적으로 화면에 노출되지 않는 이슈가 발생했다.
개발자도구 Elements 탭에서 팝업 DOM이 생성되었다가 바로 사라지는 현상이 관찰됐다.
2. 원인 분석
비동기 작업과 UI 갱신 순서 문제:
팝업 생성 후, 채팅방 목록을 새로 불러오는 함수(reloadRecentRoomList)가 바로 실행되며
SPA 구조에서 화면 일부 또는 전체가 리렌더링되면서 팝업 DOM이 바로 삭제됨
Promise/Callback 처리 미흡:
기존에는 setTimeout으로 2초 후에 UI 리로드를 시도했으나,
비동기 작업과 UI 갱신이 제대로 순차적으로 연결되지 않아 순서 보장이 되지 않았다.
3. 기술적 해결 방법
팝업 UI를 동기적으로 처리하기 위해 Promise를 활용:
팝업을 띄우는 함수(showExitDonePopup)를 Promise로 감싸
팝업이 2초간 유지된 후에만 다음 액션(채팅방 목록 리로드)이 실행되도록 구조를 변경했다.
즉,
showExitDonePopup().then(() => reloadRecentRoomList());
형태로 UI가 사용자에게 명확히 보이는 시간을 보장한 뒤,
그 후에 화면 갱신이 일어나도록 프로세스를 개선했다.
팝업 위치와 z-index, position 등 UI 세부사항 보강:
팝업이 항상 body에 append되고, position: fixed, z-index를 충분히 크게 지정하여
화면 리로드나 다른 UI 요소에 의해 가려지지 않도록 했다.
4. 왜 이렇게 해결했는가? (선택한 방식의 논리적 이유)
사용자 경험(UX) 개선:
안내 메시지가 분명하게 노출되는 것은, 사용자가 자신의 액션(채팅방 삭제)이 성공적으로 처리되었는지 즉시 인지할 수 있게 해준다.
비동기 UI 동기화 및 순서 보장은 UX 품질에 직결된다.
UI와 비동기 로직의 분리/결합:
Promise 기반으로 UI 액션과 데이터 갱신을 분리,
각각을 명확히 동기적으로 연결함으로써
코드의 유지보수성과 가독성, 확장성을 높였다.
SPA 구조에서의 팝업 UI 관리:
SPA 환경에서는 부분 렌더링, 전체 렌더링, 비동기 데이터 교체 등이 빈번하므로
UI 요소가 언제 사라질 수 있는지 항상 주의해야 한다.
팝업을 body 최상단에 append하고,
필요시 z-index/position을 조정하는 것은 SPA UI 개발에서 반드시 필요한 패턴이다.
5. 결론/요약
"채팅방 삭제 안내 팝업이 비동기 UI 갱신과 SPA 구조에서 사라지는 문제를,
Promise 기반 동기 처리로 해결하여 사용자에게 명확한 안내와 안정적인 UI 경험을 제공할 수 있었다.
이를 통해 UI/UX 품질과 코드 구조 모두를 개선하였다."