### PR TITLE
채팅방에서 채팅하고있는 상대방의 닉네임 보여주기

### DIFF
--- a/puppit/src/main/java/org/puppit/model/dto/ChatListDTO.java
+++ b/puppit/src/main/java/org/puppit/model/dto/ChatListDTO.java
@@ -22,6 +22,7 @@ public class ChatListDTO {
 	private String sellerAccountId;
 	private String sellerNickName;
 	private String buyerNickName;
+	private String buyerAccountId;
 	private Integer otherUserId;
 	private String otherAccountId;
 	private String otherUserName;

--- a/puppit/src/main/resources/mybatis/mapper/chatMessageMapper.xml
+++ b/puppit/src/main/resources/mybatis/mapper/chatMessageMapper.xml
@@ -172,16 +172,17 @@ ORDER BY c.chat_created_at ASC;
   
   
 <select id="getChatRoomsByCreatedDesc" resultType="org.puppit.model.dto.ChatListDTO" parameterType="map">
- SELECT 
+    SELECT 
         r.room_id                  AS roomId,
         r.product_id               AS productId,
         p.product_name             AS productName,
         p.product_price            AS productPrice,
         p.seller_id                AS sellerId,
-        s.nick_name                AS sellerAccountId,
+        s.account_id               AS sellerAccountId,
         s.nick_name                AS sellerNickName,
         u.user_name                AS buyerName,
         u.nick_name                AS buyerNickName,
+        u.account_id               AS buyerAccountId,
         s.user_name                AS sellerName,
         last_msg.chat_message      AS lastMessage,
         last_msg.chat_created_at   AS lastMessageAt,


### PR DESCRIPTION
Copilot said: 아래는 실제 개발 경험을 바탕으로 포트폴리오에 쓸
아래는 실제 개발 경험을 바탕으로 포트폴리오에 쓸 수 있도록 논리적으로 정리한 예시입니다.

1. 문제 상황
서비스 내 채팅방 목록 페이지에서 상대방의 닉네임이 정상적으로 표시되지 않고, "알 수 없음"이라는 메시지만 반복적으로 출력되는 문제가 있었습니다.
JSP에서 로그인 사용자와 채팅방의 구매자/판매자 정보를 비교해 상대방 닉네임을 보여주도록 구현했으나, 조건식이 항상 false로 평가되어 원하는 결과가 나오지 않았습니다.

문제 원인
DB, DTO, JSP, 세션에서 사용자 식별값(sellerAccountId, buyerAccountId, loginUserId)의 데이터 타입이 일치하지 않음.
예를 들어, DB에는 닉네임이 저장되어 있는데, 세션에는 계정 ID(account_id)가 저장되어 있거나, 채팅방 정보에는 user_id(PK, 숫자)가 들어가 있는 경우 조건식이 정상적으로 동작하지 않음.
2. 기술적 해결 방법
1) 데이터 일관성 확보
DB 쿼리, DTO, JSP, 세션까지 비교하는 값의 데이터 타입을 통일.
DB 쿼리에서 sellerAccountId, buyerAccountId를 닉네임(nick_name)에서 계정ID(account_id)로 변경.
DTO와 JSP에서도 계정ID로 값을 비교하도록 수정.
세션의 로그인 정보도 닉네임이 아닌 계정ID로 세팅.
2) 조건식 명확화
JSP 조건식을 아래와 같이 수정하여, 판매자/구매자 각각의 계정ID를 로그인한 사용자의 계정ID와 비교하도록 변경.
jsp
<c:choose>
    <c:when test="${chat.sellerAccountId eq loginAccountId}">
        <c:out value="${chat.buyerNickName}" />
    </c:when>
    <c:when test="${chat.buyerAccountId eq loginAccountId}">
        <c:out value="${chat.sellerNickName}" />
    </c:when>
    <c:otherwise>
        <c:out value="알 수 없음" />
    </c:otherwise>
</c:choose>
3) 디버깅 및 검증
JSP에 실제 값을 출력하여 값의 정합성을 검증.
jsp
sellerAccountId: ${chat.sellerAccountId}, buyerAccountId: ${chat.buyerAccountId}, loginAccountId: ${loginAccountId}
데이터를 일치시킨 후, 상대방 닉네임이 정상적으로 표시됨을 확인.
3. 왜 이런 방법을 선택했는가?
데이터 일관성의 중요성
프론트와 백엔드 모든 계층에서 비교되는 값의 형식이 일치해야 조건문이 정상적으로 동작함.
실무에서는 닉네임, 계정ID, PK 등 여러 형태의 사용자 식별자가 혼용될 수 있기 때문에,
통일된 식별자 사용은 유지보수성과 확장성을 높임.
책임 분리와 재사용성
DB에서부터 일관성 있게 account_id를 기준으로 데이터를 가져오면
프론트에서 추가적인 가공이나 변환 없이 바로 사용할 수 있음.
추후 닉네임 변경, 계정ID 변경 등 다양한 요구사항이 생겨도
핵심 식별자는 변하지 않으므로 안정적으로 동작.
디버깅의 효율성
값이 불일치할 때 빠르게 원인을 찾고 수정할 수 있도록 실제 데이터의 흐름을 명확하게 파악할 수 있음.
4. 요약
사용자 식별값의 불일치로 인해 조건문이 항상 false가 되어 “알 수 없음”만 표시되던 문제를,
DBDTO세션~JSP까지 모두 account_id로 통일하여 데이터를 비교하도록 개선함.
이를 통해 조건식이 정상적으로 동작하게 되었고,
데이터 일관성을 확보함으로써 서비스의 신뢰성과 유지보수성을 높일 수 있었다.

