### PR TITLE
채팅방 삭제 후 다른 채팅방 클릭시 메시지 내용 렌더링 잘되도록 수정

### DIFF
--- a/puppit/src/main/webapp/WEB-INF/views/chat/list.jsp
+++ b/puppit/src/main/webapp/WEB-INF/views/chat/list.jsp
@@ -942,7 +942,7 @@ function reloadRecentRoomList() {
 
              // 채팅방 아이템 HTML
                 const html =
-                    '<div class="chatList">' +
+                    '<div class="chatList" data-room-id="'+chat.roomId + '">' +
                         '<span class="chat-profile-img">' +
                             '<img src="' + imgSrc + '" alt="프로필 이미지" onerror="this.src=\'' + defaultImg + '\'"/>' +
                         '</span>' +
@@ -964,6 +964,31 @@ function reloadRecentRoomList() {
 
                 chatListRenderArea.insertAdjacentHTML('beforeend', html);
             });
+            
+            // [여기 추가!] 채팅방 클릭 이벤트 바인딩
+            chatListRenderArea.querySelectorAll('.chatList').forEach(function(chatDiv) {
+                chatDiv.addEventListener('click', function() {
+                    // 하이라이트 처리
+                    chatListRenderArea.querySelectorAll('.chatList').forEach(el => {
+                        el.classList.remove('highlight', 'selected');
+                    });
+                    chatDiv.classList.add('highlight', 'selected');
+                    const roomId = chatDiv.getAttribute('data-room-id');
+                    if (roomId) {
+                        // 메시지 영역 초기화
+                        chatHistory.innerHTML = "";
+                        renderedMessageIds.clear();
+                        showChatUI(true); // 채팅 UI 활성화
+                        loadChatHistory(roomId).then(() => {
+                            if (typeof connectAndSubscribe === 'function') {
+                                connectAndSubscribe(roomId);
+                            }
+                        });
+                    }
+                });
+            });
+            
+            
 
             // 이하 기존 이벤트 바인딩 로직은 그대로
             // ...
@@ -1110,6 +1135,7 @@ function loadChatHeader(product, buyerId, sellerId, sellerAccountId, buyerAccoun
 }
 
 function loadChatHistory(roomId) {
+	console.log('loadChatHistory() 실행');
     return fetch(contextPath + '/chat/message?roomId=' + roomId)
         .then(response => response.json())
         .then(data => {


### PR DESCRIPTION
1. 문제 상황
채팅방 목록에서 채팅방을 클릭하면
채팅방 하이라이트 효과와 해당 채팅방의 메시지 불러오기가 정상적으로 동작해야 합니다.
그러나, 채팅방을 클릭해도 메시지 불러오기 함수(loadChatHistory)가 실행되지 않거나,
실행되어도 원하는 메시지가 표시되지 않는 문제가 발생했습니다.
2. 문제 원인
동적으로 생성된 채팅방 아이템에 data-room-id 속성이 누락되어 있었습니다.
클릭 이벤트 핸들러에서는 chatDiv.dataset.roomId로 roomId를 얻어와야 하는데,
해당 속성이 없다 보니, 클릭해도 roomId가 undefined가 되어
loadChatHistory(roomId)가 정상적으로 동작하지 않았습니다.
3. 코드 수정 방법
채팅방 목록을 렌더링할 때 data-room-id 속성을 반드시 추가했습니다.
Before (문제 코드)
JavaScript
const html =
    '<div class="chatList">' + // ← data-room-id가 없음
        // ...
    '</div>';
After (수정 코드)
JavaScript
const html =
    '<div class="chatList" data-room-id="' + chat.roomId + '">' + // ← data-room-id 속성 추가
        // ...
    '</div>';
그리고 클릭 이벤트에서 얻은 roomId를 사용해
**loadChatHistory(roomId)**를 정상적으로 호출하도록 했습니다.
JavaScript
chatListRenderArea.querySelectorAll('.chatList').forEach(function(chatDiv) {
    chatDiv.addEventListener('click', function() {
        // ...
        const roomId = chatDiv.getAttribute('data-room-id');
        if (roomId) {
            chatHistory.innerHTML = "";
            renderedMessageIds.clear();
            showChatUI(true); // UI 활성화
            loadChatHistory(roomId).then(() => {
                if (typeof connectAndSubscribe === 'function') {
                    connectAndSubscribe(roomId);
                }
            });
        }
    });
});
4. 수정 이유 및 논리적 설명
왜 이렇게 수정했는가?
정확한 데이터 전달:
이벤트 핸들러에서 채팅방의 고유 식별자인 roomId를 가져와야
올바른 API 호출 및 메시지 불러오기가 가능하다.
동적 요소 관리:
동적으로 생성된 DOM 요소에 반드시 필요한 정보를 data-* 속성으로 넣어두면
이벤트 핸들러에서 쉽게 참조할 수 있다.
유지보수성:
향후 다른 기능(예: 뱃지, 메시지 알림, 하이라이트 처리 등)에서도
data-room-id를 활용해 일관된 코드 구조를 만들 수 있다.
논리적 효과
사용자 경험 개선:
채팅방을 클릭할 때마다
해당 채팅방이 하이라이트되고
관련 메시지가 즉시 보여지므로
UX가 자연스럽고 직관적이다.
버그 예방:
동적으로 그려지는 요소에 필요한 정보를 항상 포함시키면
"undefined" 또는 "빈 값" 문제로 인한 예기치 않은 동작을 방지할 수 있다.
확장성:
추후 채팅방 기능이 확장되어도
동일한 구조로 이벤트와 데이터를 처리할 수 있으므로
코드 재사용성이 높아진다.