### PR TITLE
채팅방 닉네임에 따른 프로필 이미지 고정

### DIFF
--- a/puppit/src/main/resources/mybatis/mapper/chatMessageMapper.xml
+++ b/puppit/src/main/resources/mybatis/mapper/chatMessageMapper.xml
@@ -172,31 +172,32 @@ ORDER BY c.chat_created_at ASC;
   
   
 <select id="getChatRoomsByCreatedDesc" resultType="org.puppit.model.dto.ChatListDTO" parameterType="map">
-      SELECT 
-        r.room_id                  AS roomId,
-        r.product_id               AS productId,
-        p.product_name             AS productName,
-        p.product_price            AS productPrice,
-        p.seller_id                AS sellerId,
-        s.account_id               AS sellerAccountId,
-        s.nick_name                AS sellerNickName,
-        u.user_name                AS buyerName,
-        u.nick_name                AS buyerNickName,
-        u.account_id               AS buyerAccountId,
-        s.user_name                AS sellerName,
-        last_msg.chat_message      AS lastMessage,
-        last_msg.chat_created_at   AS lastMessageAt,
-        last_msg.chat_sender       AS lastMessageSenderId,
-        sender.nick_name           AS lastMessageSenderAccountId,
-        sender.user_name           AS lastMessageSenderName,
-        last_msg.chat_receiver     AS lastMessageReceiverId,
-        receiver.nick_name         AS lastMessageReceiverAccountId,
-        receiver.user_name         AS lastMessageReceiverName,
-        COALESCE(last_msg.chat_created_at, r.room_created_at) AS sortTime
+      SELECT
+        r.room_id,
+        r.product_id,
+        p.product_name,
+        p.product_price,
+        p.seller_id,
+        buyer.account_id AS buyer_account_id,
+        p.product_name,
+        p.product_price,
+        seller.nick_name AS seller_nick_name,
+        buyer.user_name AS buyer_name,
+        buyer.nick_name AS buyer_nick_name,
+        seller.account_id AS seller_account_id,
+        seller.user_name AS seller_name,
+        last_msg.chat_message AS last_message,
+        last_msg.chat_created_at AS last_message_at,
+        last_msg.chat_sender AS last_message_sender_id,
+        sender.nick_name AS last_message_sender_account_id,
+        sender.user_name AS last_message_sender_name,
+        last_msg.chat_receiver AS last_message_receiver_id,
+        receiver.nick_name AS last_message_receiver_account_id,
+        receiver.user_name AS last_message_receiver_name
     FROM room r
     JOIN product p ON r.product_id = p.product_id
-    JOIN user u ON r.user_id = u.user_id
-    JOIN user s ON p.seller_id = s.user_id
+    JOIN user buyer ON r.user_id = buyer.user_id
+    JOIN user seller ON p.seller_id = seller.user_id
     LEFT JOIN (
         SELECT c1.*
         FROM chat c1
@@ -210,26 +211,24 @@ ORDER BY c.chat_created_at ASC;
     LEFT JOIN user sender ON last_msg.chat_sender = sender.user_id
     LEFT JOIN user receiver ON last_msg.chat_receiver = receiver.user_id
     WHERE
-          (r.user_id = #{userId}
-           OR p.seller_id = #{userId}
-           OR EXISTS (
+        (
+            r.user_id = #{userId}
+            OR p.seller_id = #{userId}
+            OR EXISTS (
                 SELECT 1
                 FROM chat c2
                 WHERE c2.chat_room_id = r.room_id
-                  AND (c2.chat_sender = #{userId} OR c2.chat_receiver = #{userId})
-           ))
-        AND NOT (
-            u.nick_name LIKE '탈퇴한회원%'
-            OR s.nick_name LIKE '탈퇴한회원%'
-            OR sender.nick_name LIKE '탈퇴한회원%'
-            OR receiver.nick_name LIKE '탈퇴한회원%'
+                  AND (#{userId} IN (c2.chat_sender, c2.chat_receiver))
+            )
         )
-        -- 탈퇴 회원(is_deleted = 1) 관련 채팅방 제외
-        AND COALESCE(u.is_deleted, 0) != 1
-        AND COALESCE(s.is_deleted, 0) != 1
-        AND (sender.is_deleted IS NULL OR sender.is_deleted != 1)
-        AND (receiver.is_deleted IS NULL OR receiver.is_deleted != 1)
-    ORDER BY sortTime DESC
+        AND COALESCE(buyer.is_deleted, 0) = 0
+        AND COALESCE(seller.is_deleted, 0) = 0
+        AND (sender.is_deleted IS NULL OR sender.is_deleted = 0)
+        AND (receiver.is_deleted IS NULL OR receiver.is_deleted = 0)
+    ORDER BY
+        (last_msg.chat_created_at IS NULL) DESC,
+        last_msg.chat_created_at DESC,
+        r.room_created_at ASC
 </select>  
 
  <!-- roomId를 기반으로 productId만 조회 -->

--- a/puppit/src/main/webapp/WEB-INF/views/layout/header.jsp
+++ b/puppit/src/main/webapp/WEB-INF/views/layout/header.jsp
@@ -849,7 +849,7 @@ document.addEventListener("DOMContentLoaded", function() {
         String(chat.chatSenderAccountId) === String(window.nickName)
       ) {
     	console.log("chatSenderAccountId: ", chat.chatSenderAccountId);
-        window.updateChatListLastMessage(chat.chatRoomId, chat.chatMessage, chat.chatCreatedAt);
+        //window.updateChatListLastMessage(chat.chatRoomId, chat.chatMessage, chat.chatCreatedAt);
       }
 
 


### PR DESCRIPTION
문제 상황
실시간 채팅 서비스 개발 중,
채팅방 목록 화면에서 상대방(대화 상대)의 닉네임과 프로필 이미지가 올바르게 표시되지 않는 문제가 발생했다.
예를 들어, 내가 구매자일 때는 판매자의 닉네임과 프로필 이미지를,
내가 판매자일 때는 구매자의 닉네임과 프로필 이미지를 보여야 하지만,
실제로는 닉네임이 바뀌지 않거나, 프로필 이미지가 왔다갔다 하는 현상이 있었다.
원인 분석
기존 코드에서는 내 계정이 구매자인지 판매자인지만으로
닉네임/프로필 이미지를 단순히 분기하여 표시했다.
하지만 DB/API에서 전달되는 정보 구조상,
판매자/구매자 각각 여러 필드(nickName, name, accountId 등)로 존재하고,
프로필이미지도 sellerProfileImageKey, receiverProfileImageKey 등으로 구분되어 있었다.
따라서 "내가 아닌 상대방" 기준으로
닉네임/이미지 정보를 정확히 선택하지 못했던 것이 문제였다.
기술적 해결 방법
상대방 정보 판단 로직 개선

내 계정(accountId)이 구매자인지/판매자인지 판단 후,
상대방의 닉네임 및 accountId를 정확히 추출하도록 로직을 개선했다.
예를 들어, 내가 구매자이면 판매자 정보를, 내가 판매자이면 구매자 정보를 뽑도록 했다.
프로필 이미지 선택 로직 분리

상대방 accountId 기준으로,
sellerProfileImageKey 또는 receiverProfileImageKey를
정확히 선택하도록 했다.
예외적으로 운영자/기타 채팅방일 경우엔 otherProfileImageKey를 사용했다.
전체 채팅방 목록 리렌더링 적용

채팅 메시지가 송수신될 때마다,
서버에서 최신 목록 데이터를 받아와서
채팅방별 상대방 정보가 항상 최신 상태로 반영되도록 했다.
부분 업데이트가 아닌 "전체 목록 리렌더링" 방식을 사용해
데이터 불일치 문제를 예방했다.
왜 이런 기술을 선택했는가?
구조적으로 안전하고 확장성 있는 방법을 위해
상대방 정보 판단 로직을 DB/API 구조에 맞게 정교하게 분리했다.
전체 리렌더링 방식은
실시간 동기화와 데이터 일관성을 보장할 수 있어
사용자 경험(UX)의 신뢰성을 높일 수 있었다.
수많은 조건 분기와 예외 상황(운영자, 자기 자신)에서도
일관된 방식으로 정보를 표시할 수 있도록 최적화했다.
결과
채팅방 목록에서 항상 상대방(대화 상대)의 닉네임과 프로필 이미지가 정확하게 표시되도록 개선하였다.
실시간 메시지 송수신 상황에서도,
구매자/판매자 역할과 상관 없이
상대방 정보를 안정적으로 보여줄 수 있게 되었다.
사용자 경험이 크게 개선되었으며,
데이터 구조 변경/확장에도 유연하게 대응할 수 있게 되었다.