### PR TITLE
채팅방 알림 메시지 클릭시 종모양 버튼 색 검정색으로 바뀌도록 수정

### DIFF
--- a/puppit/src/main/webapp/WEB-INF/views/layout/header.jsp
+++ b/puppit/src/main/webapp/WEB-INF/views/layout/header.jsp
@@ -931,6 +931,13 @@ document.addEventListener("DOMContentLoaded", function() {
 	  // deduped 결과도 찍기
 	  console.log('deduped:', deduped);
 
+	  if (deduped.length > 0) {
+		  updateAlarmBellColor(true); // 빨간색
+		} else {
+		  updateAlarmBellColor(false); // 검정색
+		}
+	  
+	  
 	  // === 팝업 UI용 roomId별로 그룹화 및 집계 ===
 	  // { roomId: { alarms: [], lastAlarm: {}, count: N } }
  	  const roomGroups = {};
@@ -1040,6 +1047,16 @@ document.addEventListener("DOMContentLoaded", function() {
 		      var liElem = alarmLink.closest('li');
 		      if (liElem) liElem.remove();
 
+		   // [!! 추가 !!] 알림이 다 사라진 경우 종모양 검정색으로 변경
+		      setTimeout(function() {
+		        var remaining = document.querySelectorAll('#alarmArea .alarm-link').length;
+		        if (remaining === 0) {
+		          updateAlarmBellColor(false); // 종모양 검정색
+		        }
+		      }, 100);
+		      
+		      
+		      
 		      // 2. 현재 클릭한 roomId에 해당하는 group.count 찾기
 		      //var groupCount = 1; // 기본값
 	    	  var groupCount = roomGroups && roomGroups[roomId] && roomGroups[roomId].count ? roomGroups[roomId].count : 1;
@@ -1151,7 +1168,10 @@ document.addEventListener("DOMContentLoaded", function() {
 		    alarmArea.style.display = "none";
 		    alarmArea.innerHTML = "";
 		    var alarmBell = document.getElementById("alarmBell");
-		    if (alarmBell) alarmBell.style.display = "inline-block";
+		    if (alarmBell) { 
+		    	alarmBell.style.display = "inline-block";
+		    	updateAlarmBellColor(false); // 검정색
+		    }
 		    if(window.alarmInterval) clearInterval(window.alarmInterval);
 		    alarmClosed = true;
 		    localStorage.setItem('puppitAlarmClosed', 'true');
@@ -1477,6 +1497,18 @@ document.addEventListener("DOMContentLoaded", function() {
 	  const q = input.value.trim();
 	  if (q) window.location.href = contextPath + "/?q=" + encodeURIComponent(q);
   });
+  
+  function updateAlarmBellColor(hasAlarm) {
+	  var alarmBell = document.getElementById('alarmBell');
+	  if (!alarmBell) return;
+	  if (hasAlarm) {
+	    alarmBell.classList.add('red');
+	    alarmBell.querySelector('i').style.color = '#e74c3c'; // 빨간색
+	  } else {
+	    alarmBell.classList.remove('red');
+	    alarmBell.querySelector('i').style.color = ''; // 원래색(검정)
+	  }
+	}
 
 
 


### PR DESCRIPTION
Copilot said: 네, 아래는 “알림 종모양 버튼의 색 상태와
네, 아래는 “알림 종모양 버튼의 색 상태와 알림 상태 동기화(빨간색/검정색)” 문제를 포트폴리오에 논리적으로 설명할 수 있도록 예시로 작성한 내용입니다.

문제 상황
기존 시스템에서 알림(메시지/채팅)이 도착하면 헤더의 종모양 버튼이 빨간색으로 표시되어 사용자가 새로운 알림을 즉시 인지할 수 있도록 설계되어 있었다. 그러나 사용자가 알림 팝업창에서 알림 메시지를 모두 읽었음에도 불구하고, 종모양 버튼의 색상이 빨간색에서 검정색으로 정상적으로 변경되지 않는 문제가 있었다.

이로 인해 사용자는 알림을 모두 확인했음에도 불구하고 계속 새로운 알림이 존재하는 것으로 오인할 수 있었고, 사용자 경험(UX)에 혼란을 줄 수 있었다. 또한, 알림과 버튼 상태가 일치하지 않으면 UI/UX 신뢰도가 저하될 위험이 있었다.

기술적 분석 및 문제 원인
종모양 버튼의 색상 상태는 알림이 있을 때 빨간색, 없을 때 검정색이어야 한다.
알림 팝업창에서 메시지를 클릭해 읽음 처리하면 실제 알림 데이터는 사라지지만,
종모양 버튼 상태(색상)는 알림 데이터 변화와 동기화되지 않았다.
버튼 색상은 서버에서 알림 fetch할 때만 갱신되고,
클라이언트에서 알림을 읽었을 때(팝업 내 클릭) 바로 갱신되지 않았다.
해결 방법
알림 팝업창에서 알림 메시지를 클릭할 때, 남아있는 알림이 없으면 종모양 버튼을 검정색으로 변경하는 로직을 구현하였다.

알림을 클릭하면 해당 알림 요소(li)를 DOM에서 제거한 뒤,
남아있는 알림 요소가 0개가 되면(즉, 모든 알림을 읽었을 때)
updateAlarmBellColor(false) 함수를 호출하여 종모양 버튼을 검정색으로 변경하였다.
이 함수는 종모양 버튼의 class와 style을 안전하게 변경하여 UI 상태를 바로 반영한다.
알림이 새로 도착하는 경우에는 기존대로 종모양 버튼을 빨간색으로 유지하도록 하였다.

서버/웹소켓으로 알림이 오면 즉시 버튼을 빨간색으로 변경한다.
구현 코드 주요 부분 (예시)
JavaScript
function updateAlarmBellColor(hasAlarm) {
  var alarmBell = document.getElementById('alarmBell');
  if (!alarmBell) return;
  var bellIcon = alarmBell.querySelector('i');
  if (!bellIcon) return;
  if (hasAlarm) {
    alarmBell.classList.add('red');
    bellIcon.style.color = '#e74c3c';
  } else {
    alarmBell.classList.remove('red');
    bellIcon.style.color = '';
  }
}

document.querySelectorAll('#alarmArea .alarm-link').forEach(function(alarmLink, idx) {
  alarmLink.addEventListener('click', function(e) {
    // 알림(li) 제거 등 기존 로직...
    setTimeout(function() {
      var remaining = document.querySelectorAll('#alarmArea .alarm-link').length;
      if (remaining === 0) {
        updateAlarmBellColor(false); // 종모양 검정색
      }
    }, 100);
  });
});
왜 이렇게 해결했는가? (논리적/기술적 근거)
동기화: 알림 데이터 변화와 UI 상태(종모양 색깔)를 즉각적으로 동기화함으로써, 사용자 경험을 개선하고 혼란을 방지함.
직관적 UX: 사용자가 알림을 모두 읽었을 때 즉시 “알림 없음” 상태를 비주얼적으로 인지할 수 있도록 함.
클라이언트-서버 비동기 일치: 서버 fetch/웹소켓 처리와 별개로, 클라이언트 단에서 즉각적으로 UI를 갱신함으로써 서버/네트워크 지연에 영향을 받지 않도록 구현.
확장 가능성: 추후 알림 종류가 늘어나거나 UI가 복잡해져도, 알림 상태와 버튼 색상 갱신 로직이 분리되어 있어 유지보수가 용이함.
기대 효과
사용자 경험의 일관성 및 신뢰성 향상
알림 상태에 대한 명확한 피드백 제공
UI/UX 오류 방지 및 유지보수 효율 증가